### PR TITLE
Style, formatting, typos clean-up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 
 .PHONY: help
 help: ## Display this help.
-        @awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-25s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-25s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 IMAGE ?= ghcr.io/githedgehog/hhdocs:latest
 RUN = docker run --rm -v ${PWD}:/docs -p 8000:8000 $(IMAGE)

--- a/docs/architecture/fabric.md
+++ b/docs/architecture/fabric.md
@@ -1,92 +1,94 @@
 # Hedgehog Network Fabric
 
-The Hedgehog Open Network Fabric is an open source network architecture that provides connectivity between virtual and
+The Hedgehog Open Network Fabric is an open-source network architecture that provides connectivity between virtual and
 physical workloads and provides a way to achieve network isolation between different groups of workloads using standard
-BGP EVPN and vxlan technology. The fabric provides a standard kubernetes interfaces to manage the elements in the
+BGP EVPN and VXLAN technology. The fabric provides a standard Kubernetes interface to manage the elements in the
 physical network and provides a mechanism to configure virtual networks and define attachments to these virtual networks.
 The Hedgehog Fabric provides isolation between different groups of workloads by placing them in different virtual
-networks called VPC's. To achieve this we define different abstractions starting from the physical network where we
-define `Connection` which defines how a physical server on the network connects to a physical switch on the fabric.
+networks called VPC's. To achieve this, it defines different abstractions starting from the physical network where
+a set of `Connection` objects defines how a physical server on the network connects to a physical switch on the fabric.
 
 ## Underlay Network
 
-The Hedgehog Fabric currently support two underlay network topologies.
+The Hedgehog Fabric currently supports two underlay network topologies.
 
 ### Collapsed Core
 
-A collapsed core topology is just a pair of switches connected in a mclag configuration with no other network elements.
+A collapsed core topology is just a pair of switches connected in a MCLAG configuration with no other network elements.
 All workloads attach to these two switches.
 
 ![image](./fabric-collapsedcore.png)
 
-The leaf's in this setup are configured to be in a mclag pair and servers can either be connected to both switches as
-a mclag port channel or as orphan ports connected to only one switch. both the leaves peer to external networks using
+The leaves in this setup are configured to be in a MCLAG pair and servers can either be connected to both switches as
+a MCLAG port channel or as orphan ports connected to only one switch. Both the leaves peer to external networks using
 BGP and act as gateway for workloads attached to them. The configuration of the underlay in the collapsed core is very
 simple and is ideal for very small deployments.
 
-### Spine - Leaf
+### Spine-Leaf
 
-A spine-leaf topology is a standard clos network with workloads attaching to leaf switches and spines providing
+A spine-leaf topology is a standard Clos network with workloads attaching to leaf switches and the spines providing
 connectivity between different leaves.
 
 ![image](./fabric-spineleaf.png)
 
-This kind of topology is useful for bigger deployments and provides all the advantages of a typical clos network.
+This kind of topology is useful for bigger deployments and provides all the advantages of a typical Clos network.
 The underlay network is established using eBGP where each leaf has a separate ASN and peers will all spines in the
-network. We used [RFC7938](https://datatracker.ietf.org/doc/html/rfc7938) as the reference for establishing the
+network. [RFC7938](https://datatracker.ietf.org/doc/html/rfc7938) was used as the reference for establishing the
 underlay network.
 
 ## Overlay Network
 
 The overlay network runs on top the underlay network to create a virtual network. The overlay network isolates control
 and data plane traffic between different virtual networks and the underlay network. Visualization is achieved in the
-hedgehog fabric by encapsulating workload traffic over vxlan tunnels that are source and terminated on the leaf switches
-in the network. The fabric using BGP-EVPN/Vxlan to enable creation and management of virtual networks on top of the
-virtual. The fabric supports multiple virtual networks over the same underlay network to support multi-tenancy. Each
-virtual network in the hedgehog fabric is identified by a VPC. In the following sections we will dive a bit deeper into
-a high level overview of how are vpc's implemented in the hedgehog fabric and it's associated objects.
+Hedgehog Fabric by encapsulating workload traffic over VXLAN tunnels that are source and terminated on the leaf switches
+in the network. The fabric uses BGP-EVPN/VXLAN to enable the creation and management of virtual networks on top of the
+physical one. The fabric supports multiple virtual networks over the same underlay network to support multi-tenancy.
+Each virtual network in the Hedgehog Fabric is identified by a VPC. The following subsections contain a high-level
+overview of how VPCs are implemented in the Hedgehog Fabric and its associated objects.
 
 ## VPC
-We know what is a VPC and how to attach workloads to a specific VPC. Let us now take a look at how is this actually
-implemented on the network to provide the view of a private network.
 
- - Each VPC is modeled as a vrf on each switch where there are VPC attachments defined for this vpc.
-   The Vrf is allocated its own VNI. The Vrf is local to each switch and the VNI is global for the entire fabric. By
-   mapping the vrf to a VNI and configuring an evpn instance in each vrf we establish a shared l3vni across the entire
-   fabric. All vrf participating in this vni can freely communicate with each other without a need for a policy. A Vlan
-   is allocated for each vrf which functions as a IRB Vlan for the vrf.
- - The vrf created on each switch corresponding to a VPC configures a BGP instance with evpn to advertise its locally
-   attached subnets and import routes from its peered VPC's. The BGP instance in the tenant vrf's does not establish
-   neighbor relationships and is purely used to advertise locally attached routes into the VPC (all vrf's with the same
-   l3vni) across leafs in the network.
- - A VPC can have multuple subnets. Each Subnet in the VPC is modeled as a Vlan on the switch. The vlan is only locally
-   significant and a given subnet might have different Vlan's on different leaves on the network. We assign a globally
-   significant vni for each subnet. This VNI is used to extend the subnet across different leaves in the network and
-   provides a view of single stretched l2 domain if the applications need it.
- - The hedgehog fabric has a built-in DHCP server which will automatically assign IP addresses to each workload
-   depending on the VPC it belongs to. This is achieved by configuring a DHCP relay on each of the server facing vlans.
-   The DHCP server is accessible through the underlay network and is shared by all vpcs in the fabric. The inbuilt DHCP
-   server is capable of identifying the source VPC of the request and assigning IP addresses from a pool allocated to the
-   VPC at creation.
- - A VPC by default cannot communicate to anyone outside the VPC and we need to define specific peering rules to allow
-   communication to external networks or to other VPCs.
+The previous subsections have described what a VPC is, and how to attach workloads to a specific VPC. Here comes a
+description of how VPCs are actually implemented on the network to provide the view of a private network.
+
+* Each VPC is modeled as a VRF on each switch where there are VPC attachments defined for this VPC. The VRF is allocated
+  its own VNI. The VRF is local to each switch and the VNI is global for the entire fabric. By mapping the VRF to a VNI
+  and configuring an EVPN instance in each VRF, a shared L3VNI is established across the entire fabric. All VRFs
+  participating in this VNI can freely communicate with each other without the need for a policy. A VLAN is allocated
+  for each VRF which functions as an IRB VLAN for the VRF.
+* The VRF created on each switch corresponding to a VPC configures a BGP instance with EVPN to advertise its locally
+  attached subnets and import routes from its peered VPCs. The BGP instance in the tenant VRFs does not establish
+  neighbor relationships and is purely used to advertise locally attached routes into the VPC (all VRFs with the same
+  L3VNI) across leaves in the network.
+* A VPC can have multuple subnets. Each subnet in the VPC is modeled as a VLAN on the switch. The VLAN is only locally
+  significant and a given subnet might have different VLANs on different leaves on the network. A globally significant
+  VNI is assigned to each subnet. This VNI is used to extend the subnet across different leaves in the network and
+  provides a view of single stretched L2 domain if the applications need it.
+* The Hedgehog Fabric has a built-in DHCP server which will automatically assign IP addresses to each workload depending
+  on the VPC it belongs to. This is achieved by configuring a DHCP relay on each of the server facing VLANs. The DHCP
+  server is accessible through the underlay network and is shared by all VPCs in the fabric. The inbuilt DHCP server is
+  capable of identifying the source VPC of the request and assigning IP addresses from a pool allocated to the VPC at
+  creation.
+* A VPC by default cannot communicate to anyone outside the VPC and specific peering rules are required to allow
+  communication to external networks or to other VPCs.
 
 ## VPC Peering
-To enable communication between 2 different VPC's we need to configure a VPC peering policy. The hedgehog fabric
+
+To enable communication between 2 different VPCs, one needs to configure a VPC peering policy. The Hedgehog Fabric
 supports two different peering modes.
 
-- Local Peering - A local peering directly imports routers from the other VPC locally. This is achieved by a simple
+* Local Peering: A local peering directly imports routers from the other VPC locally. This is achieved by a simple
   import route from the peer VPC. In case there are no locally attached workloads to the peer VPC the fabric
-  automatically creates a stub vpc for peering and imports routes from it. This allows VPC's to peer with each other
-  without the need for dedicated peering leaf. If a local peering is done for a pair of VPC's which have locally
-  attached workloads the fabric automatically allocates a pair of ports on the switch to router traffic between these
-  vrf's using static routes. This is required because of limitations in  the underlying platform. The net result of
-  this is that the bandwidth between these 2 VPC's is limited by the bandwidth of the loopback interfaces allocated
-  on the switch.
-- Remote Peering  - Remote peering is implemented using a dedicated peering switch/switches which is used as a
-  rendezvous point for the 2 VPC's in the fabric. The set of switches to be used for peering is determined by
-  configuration in the peering policy. When a remote peering policy is applied for a pair of VPC's the vrf's
-  corresponding to these VPC's on the peering switch advertise default routes into their specific vrf's identified
-  by the l3vni. All traffic that does not belong to the VPC's is forwarded to the peering switch and which has routes
-  to the other VPC's and gets forwarded from there. The bandwidth limitation that exists in the local peering solution
-  is solved here as the bandwidth between the two VPC's is determined by the fabric cross section bandwidth.
+  automatically creates a stub VPC for peering and imports routes from it. This allows VPCs to peer with each other
+  without the need for a dedicated peering leaf. If a local peering is done for a pair of VPCs which have locally
+  attached workloads, the fabric automatically allocates a pair of ports on the switch to route traffic between these
+  VRFs using static routes. This is required because of limitations in the underlying platform. The net result of these
+  limitations is that the bandwidth between these 2 VPCs is limited by the bandwidth of the loopback interfaces
+  allocated on the switch.
+* Remote Peering: Remote peering is implemented using a dedicated peering switch/switches which is used as a rendezvous
+  point for the 2 VPC's in the fabric. The set of switches to be used for peering is determined by configuration in the
+  peering policy. When a remote peering policy is applied for a pair of VPCs, the VRFs corresponding to these VPCs on
+  the peering switch advertise default routes into their specific VRFs identified by the L3VNI. All traffic that does
+  not belong to the VPCs is forwarded to the peering switch which has routes to the other VPCs and gets forwarded from
+  there. The bandwidth limitation that exists in the local peering solution is solved here as the bandwidth between the
+  two VPCs is determined by the fabric cross section bandwidth.

--- a/docs/concepts/overview.md
+++ b/docs/concepts/overview.md
@@ -2,36 +2,39 @@
 
 ## Introduction
 
-Hedgehog Open Network Fabric is build on top of Kubernetes and uses Kubernetes API to manage its resources. It means
-that all user-facing APIs are [Kubernetes Custom Resources (CRDs)](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
-and so you can use standard Kubernetes tools to manage Fabric resources.
+Hedgehog Open Network Fabric is built on top of Kubernetes and uses Kubernetes API to manage its resources. It means
+that all user-facing APIs are [Kubernetes Custom Resources (CRDs)][CRDs], so you can use standard Kubernetes tools to
+manage Fabric resources.
+
+[CRDs]: https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/
 
 Hedgehog Fabric consists of the following components:
 
-* Fabricator - special tool that allows to install and configure Fabric as well as run virtual labs
-* Control Node - one or more Kubernetes nodes in a single clusters running Fabric software
+* Fabricator - special tool to install and configure Fabric, or to run virtual labs
+* Control Node - one or more Kubernetes nodes in a single cluster running Fabric software:
     * Das Boot - set of services providing switch boot and installation
     * Fabric Controller - main control plane component that manages Fabric resources
-* Fabric Kubectl plugin (Fabric CLI) - plugin for kubectl that allows to manage Fabric resources in an easy way
+* Fabric Kubectl plugin (Fabric CLI) - kubectl plugin to manage Fabric resources in an easy way
 * Fabric Agent - runs on every switch and manages switch configuration
 
 ## Fabric API
 
-All infrastructure is represented as a set of Fabric resource (Kubernetes CRDs) and named Wiring Diagram. It allows to
-define switches, servers, control nodes, external systems and connections between them in a single place and then use
-it to deploy and manage the whole infrastructure. On top of it Fabric provides a set of APIs to manage the VPCs and
-connections between them and between VPCs and External systems.
+All infrastructure is represented as a set of Fabric resource (Kubernetes CRDs) and named Wiring Diagram. With this
+representation, Fabric defines switches, servers, control nodes, external systems and connections between them in a
+single place and then uses these definitions to deploy and manage the whole infrastructure. On top of the Wiring
+Diagram, Fabric provides a set of APIs to manage the VPCs and the connections between them and between VPCs and External
+systems.
 
 ### Wiring Diagram API
 
 Wiring Diagram consists of the following resources:
 
 * "Devices": describes any device in the Fabric
-    * __Switch__: configuration of the switch, like port group speeds, port breakouts, switch IP/ASN, etc.
-    * __Server__: any physical server attached to the Fabric including control nodes
+    * __Switch__: configuration of the switch, containing for example: port group speeds, port breakouts, switch IP/ASN
+    * __Server__: any physical server attached to the Fabric including Control Nodes
 * __Connection__: *any* logical connection for devices
     * usually it's a connection between two or more ports on two different devices
-    * incl. MCLAG Peer Link, Unbundled/MCLAG server connections, Fabric connection between spine and leaf etc.
+    * for example: MCLAG Peer Link, Unbundled/MCLAG server connections, Fabric connection between spine and leaf
 * __VLANNamespace__ -> non-overlapping VLAN ranges for attaching servers
 * __IPv4Namespace__ -> non-overlapping IPv4 ranges for VPC subnets
 
@@ -39,29 +42,29 @@ Wiring Diagram consists of the following resources:
 
 * VPC API
     * __VPC__: Virtual Private Cloud, similar to the public cloud VPC it provides an isolated private network for the
-      resources with support for multiple subnets each with user-provided VLANs and on-demand DHCP
+      resources, with support for multiple subnets, each with user-provided VLANs and on-demand DHCP
     * __VPCAttachment__: represents a specific VPC subnet assignment to the Connection object which means exact server port to a VPC binding
-    * __VPCPeering__: enables VPC to VPC connectivity (could be Local where VPCs are used or Remote peering on the border/mixed leafs)
+    * __VPCPeering__: enables VPC-to-VPC connectivity (could be Local where VPCs are used or Remote peering on the border/mixed leaves)
 * External API
     * __External__: definition of the "external system" to peer with (could be one or multiple devices such as edge/provider routers)
     * __ExternalAttachment__: configuration for a specific switch (using Connection object) describing how it connects to an external system
-    * __ExternalPeering__: enables VPC to External connectivity by exposing specific VPC subnets to the external system and allowing inbound routes from it
+    * __ExternalPeering__: provides VPC with External connectivity by exposing specific VPC subnets to the external system and allowing inbound routes from it
 
 ## Fabricator
 
 Installer builder and VLAB.
 
-* Installer builder based on a preset (currently vlab for virtual & lab for physical)
-    * Main input - wiring diagram
+* Installer builder based on a preset (currently: `vlab` for virtual and `lab` for physical)
+    * Main input: Wiring Diagram
     * All input artifacts coming from OCI registry
     * Always full airgap (everything running from private registry)
-    * Flatcar Linux for control node, generated ignition.json
-    * Automatic k3s installation and private registry setup
-    * All components and their dependencies running in K8s
+    * Flatcar Linux for Control Node, generated `ignition.json`
+    * Automatic K3s installation and private registry setup
+    * All components and their dependencies running in Kubernetes
 * Integrated Virtual Lab (VLAB) management
 * Future:
     * In-cluster (control) Operator to manage all components
-    * Upgrades handling for everything starting control node OS
+    * Upgrades handling for everything starting Control Node OS
     * Installation progress, status and retries
     * Disaster recovery and backups
 
@@ -71,27 +74,27 @@ Switch boot and installation.
 
 * Seeder
     * Actual switch provisioning
-    * ONIE on a switch discovers control node using LLDP
-    * It loads and runs our multi-stage installer
-        * Network configuration & identity setup
+    * ONIE on a switch discovers Control Node using LLDP
+    * Loads and runs Hedgehog's multi-stage installer
+        * Network configuration and identity setup
         * Performs device registration
         * Hedgehog identity partition gets created on the switch
         * Downloads SONiC installer and runs it
-        * Downloads Agent and it's config and installs to the switch
+        * Downloads Agent and its config and installs to the switch
 * Registration Controller
     * Device identity and registration
 * Actual SONiC installers
-* Misc: rsyslog/ntp
+* Miscellaneous: rsyslog/ntp
 
 ## Fabric
 
 Control plane and switch agent.
 
-* Currently Fabric is basically single controller manager running in K8s
+* Currently Fabric is basically a single controller manager running in Kubernetes
     * It includes controllers for different CRDs and needs
-    * For example, auto assigning VNIs to VPC or generating Agent config
-    * Additionally, it's running admission webhook for our CRD APIs
-* Agent is watching for the corresponding Agent CRD in K8s API
-    * It applies the changes and saves new config locally
-    * It reports back some status and information back to API
-    * Can perform reinstall and reboot of SONiC
+    * For example, auto assigning VNIs to VPCs or generating the Agent configuration
+    * Additionally, it's running the admission webhook for Hedgehog's CRD APIs
+* The Agent is watching for the corresponding Agent CRD in Kubernetes API
+    * It applies the changes and saves the new configuration locally
+    * It reports some status and information back to the API
+    * It can perform reinstallation and reboot of SONiC

--- a/docs/concepts/overview.md
+++ b/docs/concepts/overview.md
@@ -52,34 +52,34 @@ Wiring Diagram consists of the following resources:
 Installer builder and VLAB.
 
 * Installer builder based on a preset (currently vlab for virtual & lab for physical)
-  * Main input - wiring diagram
-  * All input artifacts coming from OCI registry
-  * Always full airgap (everything running from private registry)
-  * Flatcar Linux for control node, generated ignition.json
-  * Automatic k3s installation and private registry setup
-  * All components and their dependencies running in K8s
+    * Main input - wiring diagram
+    * All input artifacts coming from OCI registry
+    * Always full airgap (everything running from private registry)
+    * Flatcar Linux for control node, generated ignition.json
+    * Automatic k3s installation and private registry setup
+    * All components and their dependencies running in K8s
 * Integrated Virtual Lab (VLAB) management
 * Future:
-  * In-cluster (control) Operator to manage all components
-  * Upgrades handling for everything starting control node OS
-  * Installation progress, status and retries
-  * Disaster recovery and backups
+    * In-cluster (control) Operator to manage all components
+    * Upgrades handling for everything starting control node OS
+    * Installation progress, status and retries
+    * Disaster recovery and backups
 
 ## Das Boot
 
 Switch boot and installation.
 
 * Seeder
-  * Actual switch provisioning
-  * ONIE on a switch discovers control node using LLDP
-  * It loads and runs our multi-stage installer
-    * Network configuration & identity setup
-    * Performs device registration
-    * Hedgehog identity partition gets created on the switch
-    * Downloads SONiC installer and runs it
-    * Downloads Agent and it's config and installs to the switch
+    * Actual switch provisioning
+    * ONIE on a switch discovers control node using LLDP
+    * It loads and runs our multi-stage installer
+        * Network configuration & identity setup
+        * Performs device registration
+        * Hedgehog identity partition gets created on the switch
+        * Downloads SONiC installer and runs it
+        * Downloads Agent and it's config and installs to the switch
 * Registration Controller
-  * Device identity and registration
+    * Device identity and registration
 * Actual SONiC installers
 * Misc: rsyslog/ntp
 
@@ -88,10 +88,10 @@ Switch boot and installation.
 Control plane and switch agent.
 
 * Currently Fabric is basically single controller manager running in K8s
-  * It includes controllers for different CRDs and needs
-  * For example, auto assigning VNIs to VPC or generating Agent config
-  * Additionally, it's running admission webhook for our CRD APIs
+    * It includes controllers for different CRDs and needs
+    * For example, auto assigning VNIs to VPC or generating Agent config
+    * Additionally, it's running admission webhook for our CRD APIs
 * Agent is watching for the corresponding Agent CRD in K8s API
-  * It applies the changes and saves new config locally
-  * It reports back some status and information back to API
-  * Can perform reinstall and reboot of SONiC
+    * It applies the changes and saves new config locally
+    * It reports back some status and information back to API
+    * Can perform reinstall and reboot of SONiC

--- a/docs/getting-started/download.md
+++ b/docs/getting-started/download.md
@@ -2,11 +2,11 @@
 
 ## Getting access
 
-Prior to the General Availability, access to the full software is limited and requires Design Partner Agreement.
+Prior to General Availability, access to the full software is limited and requires Design Partner Agreement.
 Please submit a ticket with the request using [Hedgehog Support Portal](https://support.githedgehog.com/).
 
 After that you will be provided with the credentials to access the software on [GitHub Package](https://ghcr.io).
-In order to use it you need to login to the registry using the following command:
+In order to use the software, log in to the registry using the following command:
 
 ```bash
 docker login ghcr.io
@@ -15,25 +15,24 @@ docker login ghcr.io
 ## Downloading the software
 
 The main entry point for the software is the Hedgehog Fabricator CLI named `hhfab`. All software is published into the
-OCI registry [GitHub Package](https://ghcr.io) including binaries, container images, helm charts and etc.
-The latest stable `hhfab` binary can be downloaded from the [GitHub Package](https://ghcr.io) using the following
-command:
+OCI registry [GitHub Package](https://ghcr.io) including binaries, container images, or Helm charts.
+Download the latest stable `hhfab` binary from the [GitHub Package](https://ghcr.io) using the following command:
 
 ```bash
 curl -fsSL https://i.hhdev.io/hhfab | bash
 ```
 
-Or you can download a specific version using the following command:
+Or download a specific version using the following command:
 
 ```bash
 curl -fsSL https://i.hhdev.io/hhfab | VERSION=alpha-X bash
 ```
 
-The `VERSION` environment variable can be used to specify the version of the software to download. If it's not specified
-the latest release will be downloaded. You can pick specific release series (e.g. `alpha-2`) or specific release.
+Use the `VERSION` environment variable to specify the version of the software to download. By default, the latest
+release is downloaded. You can pick a specific release series (e.g. `alpha-2`) or a specific release.
 
-It requires [ORAS](https://oras.land/) to be installed which is used to download the binary from the OCI registry and
-could be installed using following command:
+The download script requires [ORAS](https://oras.land/) to be installed. ORAS is used to download the binary from the
+OCI registry and can be installed using following command:
 
 ```bash
 curl -fsSL https://i.hhdev.io/oras | bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,14 +1,14 @@
 # Introduction
 
 Hedgehog Open Network Fabric is an open networking platform that brings the user experience enjoyed by so many in the
-public cloud to the private environments. Without vendor lock-in.
+public cloud to private environments. It comes without vendor lock-in.
 
-Fabric is built around concept of VPCs (Virtual Private Clouds) similar to the public clouds and provides a multi-tenant
-API to define user intent on network isolation, connectivity and etc which gets automatically transformed into switches
-and software appliances configuration.
+Fabric is built around the concept of VPCs (Virtual Private Clouds), similar to the public clouds. It provides a
+multi-tenant API to define the user intent on network isolation and connectivity, which gets automatically transformed
+into configuration for switches and software appliances.
 
-You can read more about [concepts](concepts/overview.md) and [architecture](architecture/overview.md) in the
+You can read more about its [concepts](concepts/overview.md) and [architecture](architecture/overview.md) in the
 documentation.
 
 You can find how to [download](getting-started/download.md) and try Fabric on the self-hosted
-[fully virtualized lab](vlab/overview.md) or on the [hardware](install-upgrade/overview.md).
+[fully virtualized lab](vlab/overview.md) or on [hardware](install-upgrade/overview.md).

--- a/docs/install-upgrade/.pages
+++ b/docs/install-upgrade/.pages
@@ -4,5 +4,5 @@ nav:
   - System Requirements: requirements.md
   - Build Wiring Diagram: build-wiring.md
   - Fabric Configuration: config.md
-  - ONiE Update (prepare switch): onie-update.md
+  - ONIE Update (prepare switch): onie-update.md
   - ...

--- a/docs/install-upgrade/build-wiring.md
+++ b/docs/install-upgrade/build-wiring.md
@@ -3,8 +3,8 @@
 !!! warning ""
     Under construction.
 
-In the meantime, to have a look at the working wiring diagram for the Hedgehog Fabric, please run sample generator that
-produces VLAB-compatible wiring diagrams:
+In the meantime, to have a look at working wiring diagram for Hedgehog Fabric, run the sample generator that produces
+VLAB-compatible wiring diagrams:
 
 ```console
 ubuntu@sl-dev:~$ hhfab wiring sample -h

--- a/docs/install-upgrade/build-wiring.md
+++ b/docs/install-upgrade/build-wiring.md
@@ -6,7 +6,7 @@
 In the meantime, to have a look at the working wiring diagram for the Hedgehog Fabric, please run sample generator that
 produces VLAB-compatible wiring diagrams:
 
-```bash
+```console
 ubuntu@sl-dev:~$ hhfab wiring sample -h
 NAME:
    hhfab wiring sample - sample wiring diagram (would work for vlab)

--- a/docs/install-upgrade/config.md
+++ b/docs/install-upgrade/config.md
@@ -6,7 +6,7 @@
     `time.cloudflare.com,time1.google.com,time2.google.com,time3.google.com,time4.google.com`, it'll be used for both
     control nodes and switches
 * `--dhcpd <mode-name>` (`isc` or `hedgehog`) - DHCP server to use, default is `isc`; `hedgehog` DHCP server enables
-    use of on-demand DHCP for multiple IPv4/VLAN namespaces and overlapping IP ranges as well as adds DHCP leases
+    use of on-demand DHCP for multiple IPv4/VLAN namespaces and overlapping IP ranges, and it adds DHCP leases
     into the Fabric API
 
-You can find more information about using `hhfab init` in the help message by running it with `--help` flag.
+For more information about how to use `hhfab init`, run `hhfab init --help`.

--- a/docs/install-upgrade/onie-update.md
+++ b/docs/install-upgrade/onie-update.md
@@ -42,112 +42,61 @@
 
   * ONIE will install the ONIE update and reboot
 
-    * `ONIE: OS Install Mode ...
-
-      Platform  : x86_64-dellemc_s5200_c3538-r0
-
-      <mark>Version   : 3.40.1.1-7</mark> <- Non HONIE version
-
-      Build Date: 2020-03-24T20:44-07:00
-
-      Info: Mounting EFI System on /boot/efi ...
-
-      Info: BIOS mode: UEFI
-
-      Info: Making NOS install boot mode persistent.
-
-      Info: Using eth0 MAC address: 3c:2c:30:66:f0:00
-
-      Info: eth0:  Checking link... up.
-
-      Info: Trying DHCPv4 on interface: eth0
-
-      Warning: Unable to configure interface using DHCPv4: eth0
-
-      ONIE: Using link-local IPv4 addr: eth0: 169.254.95.249/16
-
-      Starting: klogd... done.
-
-      Starting: dropbear ssh daemon... done.
-
-      Starting: telnetd... done.
-
-      discover: installer mode detected.  Running installer.
-
-      Starting: discover... done.
-
-      Please press Enter to activate this console. Info: eth0:  Checking link... up.
-
-      Info: Trying DHCPv4 on interface: eth0
-
-      Warning: Unable to configure interface using DHCPv4: eth0
-
-      ONIE: Using link-local IPv4 addr: eth0: 169.254.6.139/16
-
-      ONIE: Starting ONIE Service Discovery
-
-      Info: Attempting file://dev/sdb1/onie-installer-x86_64-dellemc_s5248f_c3538-r0 ...
-
-      Info: Attempting file://dev/mmcblk0p1/onie-installer-x86_64-dellemc_s5248f_c3538-r0 ...
-
-      Info: Attempting file://dev/mmcblk0p1/onie-installer-x86_64-dellemc_s5248f_c3538-r0.bin ...
-
-      Info: Attempting file://dev/mmcblk0p1/onie-installer-x86_64-dellemc_s5248f_c3538.bin ...
-
-      Info: Attempting file://dev/mmcblk0p1/onie-installer-dellemc_s5248f_c3538 ...
-
-      Info: Attempting file://dev/mmcblk0p1/onie-installer-dellemc_s5248f_c3538.bin ...
-
-      Info: Attempting file://dev/mmcblk0p1/onie-installer-x86_64-bcm ...
-
-      Info: Attempting file://dev/mmcblk0p1/onie-installer-x86_64-bcm.bin ...
-
-      Info: Attempting file://dev/mmcblk0p1/onie-installer-x86_64 ...
-
-      Info: Attempting file://dev/mmcblk0p1/onie-installer-x86_64.bin ...
-
-      Info: Attempting file://dev/mmcblk0p1/onie-installer ...
-
-      Info: Attempting file://dev/mmcblk0p1/onie-installer.bin ...
-
-      ONIE: Executing installer: file://dev/sdb1/onie-installer-x86_64-dellemc_s5248f_c3538-r0
-
-      Verifying image checksum ... OK.
-
-      Preparing image archive ... OK.
-
-      <mark>ONIE: Version       : 3.40.1.1-8</mark> <- HONIE Version
-
-      ONIE: Architecture  : x86_64
-
-      ONIE: Machine       : dellemc_s5200_c3538
-
-      ONIE: Machine Rev   : 0
-
-      ONIE: Config Version: 1
-
-      ONIE: Build Date    : 2023-12-15T23:43+00:00
-
-      Installing ONIE on: /dev/sda
-
-      ONIE: NOS install successful: file://dev/sdb1/onie-installer-x86_64-dellemc_s5248f_c3538-r0
-
-      ONIE: Rebooting...
-
-      discover: installer mode detected.
-
-      Stopping: discover...start-stop-daemon: warning: killing process 665: No such process
-
-      Info: Unmounting kernel filesystems
-
-      umount: can't unmount /: Invalid argument
-
-      The system is going down NOW!
-
-      Sent SIGTERM to all processes
-
-      Sent SIGKILL to all processes
-
-      Requesting system reboot`
+    ```hl_lines="3 38"
+    ONIE: OS Install Mode ...
+    Platform  : x86_64-dellemc_s5200_c3538-r0
+    Version   : 3.40.1.1-7 <- Non HONIE version
+    Build Date: 2020-03-24T20:44-07:00
+    Info: Mounting EFI System on /boot/efi ...
+    Info: BIOS mode: UEFI
+    Info: Making NOS install boot mode persistent.
+    Info: Using eth0 MAC address: 3c:2c:30:66:f0:00
+    Info: eth0:  Checking link... up.
+    Info: Trying DHCPv4 on interface: eth0
+    Warning: Unable to configure interface using DHCPv4: eth0
+    ONIE: Using link-local IPv4 addr: eth0: 169.254.95.249/16
+    Starting: klogd... done.
+    Starting: dropbear ssh daemon... done.
+    Starting: telnetd... done.
+    discover: installer mode detected.  Running installer.
+    Starting: discover... done.
+    Please press Enter to activate this console. Info: eth0:  Checking link... up.
+    Info: Trying DHCPv4 on interface: eth0
+    Warning: Unable to configure interface using DHCPv4: eth0
+    ONIE: Using link-local IPv4 addr: eth0: 169.254.6.139/16
+    ONIE: Starting ONIE Service Discovery
+    Info: Attempting file://dev/sdb1/onie-installer-x86_64-dellemc_s5248f_c3538-r0 ...
+    Info: Attempting file://dev/mmcblk0p1/onie-installer-x86_64-dellemc_s5248f_c3538-r0 ...
+    Info: Attempting file://dev/mmcblk0p1/onie-installer-x86_64-dellemc_s5248f_c3538-r0.bin ...
+    Info: Attempting file://dev/mmcblk0p1/onie-installer-x86_64-dellemc_s5248f_c3538.bin ...
+    Info: Attempting file://dev/mmcblk0p1/onie-installer-dellemc_s5248f_c3538 ...
+    Info: Attempting file://dev/mmcblk0p1/onie-installer-dellemc_s5248f_c3538.bin ...
+    Info: Attempting file://dev/mmcblk0p1/onie-installer-x86_64-bcm ...
+    Info: Attempting file://dev/mmcblk0p1/onie-installer-x86_64-bcm.bin ...
+    Info: Attempting file://dev/mmcblk0p1/onie-installer-x86_64 ...
+    Info: Attempting file://dev/mmcblk0p1/onie-installer-x86_64.bin ...
+    Info: Attempting file://dev/mmcblk0p1/onie-installer ...
+    Info: Attempting file://dev/mmcblk0p1/onie-installer.bin ...
+    ONIE: Executing installer: file://dev/sdb1/onie-installer-x86_64-dellemc_s5248f_c3538-r0
+    Verifying image checksum ... OK.
+    Preparing image archive ... OK.
+    ONIE: Version       : 3.40.1.1-8 <- HONIE Version
+    ONIE: Architecture  : x86_64
+    ONIE: Machine       : dellemc_s5200_c3538
+    ONIE: Machine Rev   : 0
+    ONIE: Config Version: 1
+    ONIE: Build Date    : 2023-12-15T23:43+00:00
+    Installing ONIE on: /dev/sda
+    ONIE: NOS install successful: file://dev/sdb1/onie-installer-x86_64-dellemc_s5248f_c3538-r0
+    ONIE: Rebooting...
+    discover: installer mode detected.
+    Stopping: discover...start-stop-daemon: warning: killing process 665: No such process
+    Info: Unmounting kernel filesystems
+    umount: can't unmount /: Invalid argument
+    The system is going down NOW!
+    Sent SIGTERM to all processes
+    Sent SIGKILL to all processes
+    Requesting system reboot
+    ```
 
   * System is now ready for use

--- a/docs/install-upgrade/onie-update.md
+++ b/docs/install-upgrade/onie-update.md
@@ -18,29 +18,27 @@
 
 ## Updating ONIE
 
-* Via USB
+### Via USB
 
-  * For this example we will be updating a DELL S5248 to Hedgehog ONIE (HONIE)
+This example shows how to update a DELL S5248 to Hedgehog ONIE (HONIE).
 
-    * Note: the USB port is on the back of the switch with the Management and Console
+!!! note ""
+    Note: the USB port is on the back of the switch with the Management and Console.
 
-  * Prepare the USB stick by burning the honie-usb.img to a 4G or larger USB drive
+1. Prepare the USB stick by burning the honie-usb.img to a 4G or larger USB drive.
 
-  * Insert the USB drive into the switch
+2. Insert the USB drive into the switch. For example, burn the file to disk `X` of a macOS machine with
+   `sudo dd if=honie-usb.img of=/dev/rdiskX bs=1m`.
 
-    * For example, to burn the file to disk X of an OSX machine
+3. Boot into ONIE Installer
 
-      * sudo dd if=honie-usb.img of=/dev/rdiskX bs=1m
+    * First select ONIE:
+      ![](./onie-update-grub-onie.png)
 
-  * Boot into ONIE Installer
+    * Then request the installation:
+      ![](./onie-update-onie-install.png)
 
-    * ![](./onie-update-grub-onie.png)
-
-    * ![](./onie-update-onie-install.png)
-
-    *
-
-  * ONIE will install the ONIE update and reboot
+4. ONIE will install the ONIE update and reboot. Here are some sample logs:
 
     ```hl_lines="3 38"
     ONIE: OS Install Mode ...
@@ -99,4 +97,4 @@
     Requesting system reboot
     ```
 
-  * System is now ready for use
+5. The system is now ready for use.

--- a/docs/install-upgrade/onie-update.md
+++ b/docs/install-upgrade/onie-update.md
@@ -3,18 +3,13 @@
 ## Hedgehog ONIE (HONIE) Supported Systems
 
 * DELL
-
-  * S5248F-ON
-
-  * S5232F-ON
+    * S5248F-ON
+    * S5232F-ON
 
 * Edge-Core
-
-  * DCS501 (AS7726-32X)
-
-  * DCS203 (AS7326-56X)
-
-  * EPS203 (AS4630-54NPE)
+    * DCS501 (AS7726-32X)
+    * DCS203 (AS7326-56X)
+    * EPS203 (AS4630-54NPE)
 
 ## Updating ONIE
 

--- a/docs/install-upgrade/overview.md
+++ b/docs/install-upgrade/overview.md
@@ -5,21 +5,22 @@
 
 ## Prerequisites
 
-* Have a machine with access to internet to use Fabricator and build installer
+* Have a machine with access to the Internet to use Fabricator and build installer
 * Have a machine to install Fabric Control Node on with enough NICs to connect to at least one switch using Front Panel
-  ports and enough CPU and RAM ([System Requirements](./requirements.md)) as well as IPMI access to it to install OS
+  ports and enough CPU and RAM (see [System Requirements](./requirements.md)) as well as IPMI access to it to install
+  the OS
 * Have enough [Supported Switches](./supported-devices.md) for your Fabric
 
 ## Main steps
 
-This chapter is dedicated to the Hedgehog Fabric installation on the bare-metal control node(s) and switches, their
+This chapter is dedicated to the Hedgehog Fabric installation on bare-metal control node(s) and switches, their
 preparation and configuration.
 
-Please, get `hhfab` installed following instructions from the [Download](../getting-started/download.md) section.
+Get `hhfab` installed following instructions from the [Download](../getting-started/download.md) section.
 
-Main steps to install Fabric are:
+The main steps to install Fabric are:
 
-1. Install `hhfab` on the machines with access to internet
+1. Install `hhfab` on the machines with access to the Internet
     1. [Prepare Wiring Diagram](./build-wiring.md)
     1. [Select Fabric Configuration](./config.md)
     1. [Build Control Node configuration and installer](#build-control-node-configuration-and-installer)
@@ -28,26 +29,27 @@ Main steps to install Fabric are:
     1. Upload and run Control Node installer on the Control Node
 1. Prepare supported switches
     1. [Install Hedgehog ONIE (HONIE) on them](./onie-update.md)
-    1. Reboot them into ONIE Install Mode and they will be automatically provisioned
+    1. Reboot them into ONIE Install Mode to have them automatically provisioned
 
 ## Build Control Node configuration and installer
 
-It's the only step that requires internet access to download artifacts and build installer.
+It's the only step that requires Internet access, to download artifacts and build the installer.
 
-Once you've prepared Wiring Diagram, you can initialize Fabricator by running `hhfab init` command and passwing optional
+Once you've prepared the Wiring Diagram, initialize Fabricator by running `hhfab init` command and passing optional
 configuration into it as well as wiring diagram file(s) as flags. Additionally, there are a lot of customizations
-available as flags, e.g. to setup default credentials, keys and etc, please, refer to `hhfab init --help` for more.
+available as flags, e.g. to setup default credentials, keys and etc. For more details on the command invocation,
+refer to `hhfab init --help`.
 
-The `--dev` options allows to enable development mode which will enable default credentials and keys for the Control
+The `--dev` option activates the development mode which enables default credentials and keys for the Control
 Node and switches:
 
-* Default user with passwordless sudo for the control node and test servers is `core` with password `HHFab.Admin!`.
+* Default user with passwordless sudo for the Control Node and test servers is `core` with password `HHFab.Admin!`.
 * Admin user with full access and passwordless sudo for the switches is `admin` with password `HHFab.Admin!`.
 * Read-only, non-sudo user with access only to the switch CLI for the switches is `op` with password `HHFab.Op!`.
 
 Alternatively, you can pass your own credentials and keys using `--authorized-key` and `--control-password-hash` flags.
-Password hash can be generated using `openssl passwd -5` command. Further customizations are available in the config
-file that could be passed using `--config` flag.
+Generate a password hash with command `openssl passwd -5`. Further customization items are available in the config
+file and can be passed using the `--config` flag.
 
 ```bash
 hhfab init --preset lab --dev --wiring file1.yaml --wiring file2.yaml
@@ -56,39 +58,40 @@ hhfab build
 
 As a result, you will get the following files in the `.hhfab` directory or the one you've passed using `--basedir` flag:
 
-* `control-os/ignition.json` - ignition config for the control node to get OS installed
-* `control-install.tgz` - installer for the control node, it will be uploaded to the control node and run there
+* `control-os/ignition.json` - ignition config for the Control Node to get OS installed
+* `control-install.tgz` - installer for the Control Node, it will be uploaded to the Control Node and run there
 
 ## Install Control Node
 
-It's fully air-gapped installation and doesn't require internet access.
+Control Node installation is fully air-gapped and doesn't require Internet access.
 
-Please, download latest stable Flatcar Container Linux ISO from the
-[link](https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_iso_image.iso) and boot into it
-(using IPMI attaching media, USB stick or any other way).
+Download the [latest stable Flatcar Container Linux ISO][Flatcar ISO] and boot into it (using IPMI attaching media, USB
+stick or any other way).
 
-Once you've booted into the Flatcar installer, you need to download `ignition.json` built in the prvious step to it and
-run Flatcar installation:
+[Flatcar ISO]: https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_iso_image.iso
+
+Once you've booted into the Flatcar installer, upload the file `ignition.json` built during the previous step to the
+system and run the Flatcar installation:
 
 ```bash
 sudo flatcar-install -d /dev/sda -i ignition.json
 ```
 
 Where `/dev/sda` is a disk you want to install Control Node to and `ignition.json` is the `control-os/ignition.json`
-file from previous step downloaded to the Flatcar installer.
+file from previous step uploaded to the Flatcar installer.
 
 Once the installation is finished, reboot the machine and wait for it to boot into the installed Flatcar Linux.
 
 At that point, you should get into the installed Flatcar Linux using the dev or provided credentials with user `core`
 and you can now install Hedgehog Open Network Fabric on it. Download `control-install.tgz` to the just installed Control
-Node (e.g. by using scp) and run it.
+Node (for example, by using scp) and run it.
 
 ```bash
 tar xzf control-install.tgz && cd control-install && sudo ./hhfab-recipe run
 ```
 
-It'll output log of installing the Fabric (including Kubernetes cluster, OCI registry misc components and etc), you should see
-following output in the end:
+The command prints the logs generated while installing Fabric (including logs from the Kubernetes cluster, miscellaneous
+OCI registry misc components, and more). At the end, you should observe lines similar to the following:
 
 ```
 ...
@@ -100,8 +103,8 @@ deployment.apps/reloader-reloader condition met
 01:35:15 INF Done took=3m39.586394608s
 ```
 
-At that point, you can start interacting with the Fabric using `kubectl`, `kubectl fabric` and `k9s` preinstalled as
-part of the Control Node installer.
+At that point, you can start interacting with the Fabric using `kubectl`, `kubectl fabric` and `k9s`, all preinstalled
+as part of the Control Node installer.
 
-You can now get HONIE installed on your switches and reboot them into ONIE Install Mode and they will be automatically
+You can now get HONIE installed on your switches and reboot them into ONIE Install Mode to have them automatically
 provisioned from the Control Node.

--- a/docs/install-upgrade/overview.md
+++ b/docs/install-upgrade/overview.md
@@ -90,7 +90,7 @@ tar xzf control-install.tgz && cd control-install && sudo ./hhfab-recipe run
 It'll output log of installing the Fabric (including Kubernetes cluster, OCI registry misc components and etc), you should see
 following output in the end:
 
-```bash
+```
 ...
 01:34:45 INF Running name=reloader-image op="push fabricator/reloader:v1.0.40"
 01:34:47 INF Running name=reloader-chart op="push fabricator/charts/reloader:1.0.40"

--- a/docs/install-upgrade/overview.md
+++ b/docs/install-upgrade/overview.md
@@ -27,8 +27,8 @@ Main steps to install Fabric are:
     1. Install Flatcar Linux on the Control Node
     1. Upload and run Control Node installer on the Control Node
 1. Prepare supported switches
-    1. [Install Hedgehog ONiE (HONiE) on them](./onie-update.md)
-    1. Reboot them into ONiE Install Mode and they will be automatically provisioned
+    1. [Install Hedgehog ONIE (HONIE) on them](./onie-update.md)
+    1. Reboot them into ONIE Install Mode and they will be automatically provisioned
 
 ## Build Control Node configuration and installer
 
@@ -103,5 +103,5 @@ deployment.apps/reloader-reloader condition met
 At that point, you can start interacting with the Fabric using `kubectl`, `kubectl fabric` and `k9s` preinstalled as
 part of the Control Node installer.
 
-You can now get HONiE installed on your switches and reboot them into ONiE Install Mode and they will be automatically
+You can now get HONIE installed on your switches and reboot them into ONIE Install Mode and they will be automatically
 provisioned from the Control Node.

--- a/docs/install-upgrade/requirements.md
+++ b/docs/install-upgrade/requirements.md
@@ -1,14 +1,14 @@
 # System Requirements
 
-- Fast SSDs for system/root and K8s & container runtime folders are required for stable work
+- Fast SSDs for system/root as well as Kubernetes and container runtime folders are required for stable work
 - SSDs are mandatory for Control Nodes
 - Minimal (non-HA) setup is a single Control Node
 - (Future) Full (HA) setup is at least 3 Control Nodes
-- (Future) Extra nodes could be used for things like Logging, Monitoring, Alerting stack and etc.
+- (Future) Extra nodes could be used for things like Logging, Monitoring, Alerting stack, and more
 
 ## Non-HA (minimal) setup - 1 Control Node
 
-- Control Node runs non-HA K8s Control Plane installation with non-HA Hedgehog Fabric Control Plane on top of it
+- Control Node runs non-HA Kubernetes Control Plane installation with non-HA Hedgehog Fabric Control Plane on top of it
 - Not recommended for more then 10 devices participating in the Hedgehog Fabric or production deployments
 
 |      | Minimal | Recommended |
@@ -19,9 +19,9 @@
 
 ## (Future) HA setup - 3+ Control Nodes (per node)
 
-- Each Control Node runs part of the HA K8s Control Plane installation with Hedgehog Fabric Control Plane on top of it in
-  HA mode as well
-- Recommended for all cases where more then 10 devices participating in the Hedgehog Fabric
+- Each Control Node runs part of the HA Kubernetes Control Plane installation with Hedgehog Fabric Control Plane on top
+  of it in HA mode as well
+- Recommended for all cases where more than 10 devices participating in the Hedgehog Fabric
 
 |      | Minimal | Recommended |
 | ---- | ------- | ----------- |
@@ -31,8 +31,8 @@
 
 ## Device participating in the Hedgehog Fabric (e.g. switch)
 
-- (Future) Each participating device is part of the K8s cluster, so, it run K8s kubelet
-- Additionally it run Hedgehog Fabric Agent that controls devices configuration
+- (Future) Each participating device is part of the Kubernetes cluster, so it runs Kubernetes kubelet
+- Additionally, it runs the Hedgehog Fabric Agent that controls devices configuration
 
 |      | Minimal | Recommended |
 | ---- | ------- | ----------- |

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -231,7 +231,7 @@ To enable local inter-vpc peering that allows routing of traffic between VPCs, l
 
 * Maximum fabric size: 20 LEAF/ToR switches.
 * Routes per switch: 64k
-  * [ silicon platform limitation in Trident 3; limits te number of endpoints in the fabric  ]
+  * [ silicon platform limitation in Trident 3; limits to number of endpoints in the fabric  ]
 * Total VPCs per switch: up to 1000
   * [ Including VPCs attached at the given switch and VPCs peered with ]
 * Total VPCs per VLAN namespace: up to 3000
@@ -265,7 +265,7 @@ To enable local inter-vpc peering that allows routing of traffic between VPCs, l
 * no support for Access VLANs for attaching servers (A3 planned)
 * VPC peering is enabled on all subnets of the participating VPCs. No subnet selection for peering. (A3 planned)
 * peering with external is only possible with a VLAN (by design)
-* If you have VPCs with remote peering on a switch group, you can’t attach those VPCs on that switch group (by definition of remote peering)
+* If you have VPCs with remote peering on a switch group, you can't attach those VPCs on that switch group (by definition of remote peering)
 * if a group of VPCs has remote peering on a switch group, any other VPC that will peer with those VPCs remotely will need to use the same switch group (by design)
 * if VPC peers with external, it can only be remotely peered with on the same switches that have a connection to that external (by design)
 * the server-facing connection object is immutable as it’s very easy to get into a deadlock, re-create to change it (A3+)
@@ -309,7 +309,7 @@ To enable local inter-vpc peering that allows routing of traffic between VPCs, l
     * VPC peering is performed via ACLs with no fine-grained control.
 
 * NAT
-    * DNAT + SNAT are supported per VPC. SNAT and DNAT can’t be enabled per VPC simultaneously.
+    * DNAT + SNAT are supported per VPC. SNAT and DNAT can't be enabled per VPC simultaneously.
 
 * Hardware support:
     * Please see the supported hardware list.

--- a/docs/user-guide/connections.md
+++ b/docs/user-guide/connections.md
@@ -1,6 +1,6 @@
 # Connections
 
-The `Connection` object represents a logical and physical connections between any devices in the Fabric (`Switch`,
+The `Connection` object represents logical and physical connections between any devices in the Fabric (`Switch`,
 `Server` and `External` objects). It's needed to define all connections between the devices in the Wiring Diagram.
 
 There are multiple types of connections.
@@ -11,7 +11,7 @@ Server connections are used to connect workload servers to the switches.
 
 ### Unbundled
 
-Unbundled server connections are used to connect servers to the single switche using a single port.
+Unbundled server connections are used to connect servers to a single switch using a single port.
 
 ```yaml
 apiVersion: wiring.githedgehog.com/v1alpha2
@@ -30,7 +30,7 @@ spec:
 
 ### Bundled
 
-Bundled server connections are used to connect servers to the single switch using multiple ports (port channel, LAG).
+Bundled server connections are used to connect servers to a single switch using multiple ports (port channel, LAG).
 
 ```yaml
 apiVersion: wiring.githedgehog.com/v1alpha2
@@ -53,9 +53,9 @@ spec:
 
 ### MCLAG
 
-MCLAG server connections are used to connect servers to the pair of switches using multiple ports (Dual-homing).
+MCLAG server connections are used to connect servers to a pair of switches using multiple ports (Dual-homing).
 Switches should be configured as an MCLAG pair which requires them to be in a single redundancy group of type `mclag`
-and Connection with type `mclag-domain` between them. MCLAG switches should also have the same `spec.ASN` and
+and a Connection with type `mclag-domain` between them. MCLAG switches should also have the same `spec.ASN` and
 `spec.VTEPIP`.
 
 ```yaml
@@ -80,7 +80,8 @@ spec:
 ### ESLAG
 
 ESLAG server connections are used to connect servers to the 2-4 switches using multiple ports (Multi-homing). Switches
-should belong to the same redundancy group with type `eslag`, but no other configuration like in MCLAG case is required.
+should belong to the same redundancy group with type `eslag`, but contrary to the MCLAG case, no other configuration is
+required.
 
 ```yaml
 apiVersion: wiring.githedgehog.com/v1alpha2
@@ -108,7 +109,7 @@ the Fabric features.
 
 ### Fabric
 
-Connections between specific spine and leaf, covers all actual wires between a single pair.
+A Fabric Connections is used between specific spine and leaf, it covers all actual wires between a single pair.
 
 ```yaml
 apiVersion: wiring.githedgehog.com/v1alpha2
@@ -135,9 +136,9 @@ spec:
 
 ### MCLAG-Domain
 
-Used to define a pair of MCLAG switches with Session and Peer link between them. Switches should be configured as an
-MCLAG pair which requires them to be in a single redundancy group of type `mclag` and Connection with type
-`mclag-domain` between them. MCLAG switches should also have the same `spec.ASN` and `spec.VTEPIP`.
+MCLAG-Domain connections define a pair of MCLAG switches with Session and Peer link between them. Switches should be
+configured as an MCLAG, pair which requires them to be in a single redundancy group of type `mclag` and Connection with
+type `mclag-domain` between them. MCLAG switches should also have the same `spec.ASN` and `spec.VTEPIP`.
 
 ```yaml
 apiVersion: wiring.githedgehog.com/v1alpha2
@@ -169,8 +170,8 @@ spec:
 
 ### VPC-Loopback
 
-Required to implement a workaround for the local VPC peering (when both VPC are attached to the same switch) which is
-caused by the hardware limitation of the currently supported switches.
+VPC-Loopback connections are required in order to implement a workaround for the local VPC peering (when both VPC are
+attached to the same switch), which is caused by a hardware limitation of the currently supported switches.
 
 ```yaml
 apiVersion: wiring.githedgehog.com/v1alpha2
@@ -193,7 +194,7 @@ spec:
 
 ## Management
 
-Connection to the Control Node.
+Management connections define connections to the Control Node.
 
 ```yaml
 apiVersion: wiring.githedgehog.com/v1alpha2
@@ -212,14 +213,15 @@ spec:
         port: s5248-01/Ethernet0
 ```
 
-## Connecting Fabric to outside world
+## Connecting Fabric to the outside world
 
-Provides connectivity to the outside world, e.g. internet, other networks or some other systems such as DHCP, NTP, LMA,
-AAA services.
+Connections in this section provide connectivity to the outside world. For example, they can be connections to the
+Internet, to other networks, or to some other systems such as DHCP, NTP, LMA, or AAA services.
 
 ### StaticExternal
 
-Simple way to connect things like DHCP server directly to the Fabric by connecting it to specific switch ports.
+StaticExternal connections provide a simple way to connect things like DHCP servers directly to the Fabric by connecting
+them to specific switch ports.
 
 ```yaml
 apiVersion: wiring.githedgehog.com/v1alpha2
@@ -231,17 +233,17 @@ spec:
   staticExternal:
     link:
       switch:
-        port: s5248-04/Ethernet1 # switch port to use
+        port: s5248-04/Ethernet1 # Switch port to use
         ip: 172.30.50.5/24 # IP address that will be assigned to the switch port
-        vlan: 1005 # Optional VLAN ID to use for the switch port, if 0 - no VLAN is configured
-        subnets: # List of subnets that will be routed to the switch port using static routes and next hop
+        vlan: 1005 # Optional VLAN ID to use for the switch port; if 0, no VLAN is configured
+        subnets: # List of subnets to route to the switch port using static routes and next hop
           - 10.99.0.1/24
           - 10.199.0.100/32
-        nextHop: 172.30.50.1 # Next hop IP address that will be used when configuring static routes for the "subnets" list
+        nextHop: 172.30.50.1 # Next hop IP address to use when configuring static routes for the "subnets" list
 ```
 
 Additionally, it's possible to configure `StaticExternal` within the VPC to provide access to the third-party resources
-within a specific VPC with the same rest of the configuration.
+within a specific VPC, with the rest of the YAML configuration remaining unchanged.
 
 ```yaml
 ...
@@ -254,8 +256,8 @@ spec:
 
 ### External
 
-Connection to the external systems, e.g. edge/provider routers using BGP peering and configuring Inbound/Outbound
-communities as well as granularly controlling what's getting advertised and which routes are accepted.
+Connection to external systems, such as edge/provider routers using BGP peering and configuring Inbound/Outbound
+communities as well as granularly controlling what gets advertised and which routes are accepted.
 
 ```yaml
 apiVersion: wiring.githedgehog.com/v1alpha2

--- a/docs/user-guide/devices.md
+++ b/docs/user-guide/devices.md
@@ -1,14 +1,14 @@
 # Switches and Servers
 
-All devices in the Hedgehog Fabric are divided into two groups: switches and servers and represented by corresponding
-`Switch` and `Server` objects in the API. It's needed to define all participants of the Fabric and their roles in the
-Wiring Diagram as well as [Connections](./connections.md) between them.
+All devices in the Hedgehog Fabric are divided into two groups: switches and servers, represented by the corresponding
+`Switch` and `Server` objects in the API. These objects are needed to define all participants of the Fabric and their
+roles in the Wiring Diagram as well as [Connections](./connections.md) between them.
 
 ## Switches
 
-Switches are the main building blocks of the Fabric. They are represented by `Switch` objects in the API and consists
-of the basic information like name, description, location, role, etc. as well as port group speeds, port breakouts, ASN,
-IP addresses and etc.
+Switches are the main building blocks of the Fabric. They are represented by `Switch` objects in the API. These objects
+consist of basic metadata like name, description, location, role, as well as port group speeds, port breakouts, ASN,
+IP addresses, and more.
 
 ```yaml
 apiVersion: wiring.githedgehog.com/v1alpha2
@@ -56,16 +56,17 @@ spec: {}
 ## Redundancy Groups
 
 Redundancy groups are used to define the redundancy between switches. It's a regular `SwitchGroup` used by multiple
-switches and currently it could be MCLAG or ESLAG (EVPN MH / ESI). Switch can only belong to a single redundancy group.
+switches and currently it could be MCLAG or ESLAG (EVPN MH / ESI). A switch can only belong to a single redundancy
+group.
 
 MCLAG is only supported for pair of switches and ESLAG is supported for up to 4 switches. Multiple types of redundancy
 groups can be used in the fabric simultaneously.
 
-Connections with types `mclag` and `eslag` are used to define the servers connections to switches and only supported if
-switch belongs to a redundancy group with corresponding type.
+Connections with types `mclag` and `eslag` are used to define the servers connections to switches. They are only
+supported if the switch belongs to a redundancy group with the corresponding type.
 
-In order to define MCLAG or ESLAG redundancy group, you need to create a `SwitchGroup` object and assign it to the
-switches using `redundancy` field.
+In order to define a MCLAG or ESLAG redundancy group, you need to create a `SwitchGroup` object and assign it to the
+switches using the `redundancy` field.
 
 Example of switch configured for ESLAG:
 
@@ -113,12 +114,12 @@ spec:
   ...
 ```
 
-In case of MCLAG it's required to have a special connection with type `mclag-domain` that defines peer and session links
-between switches, for more details see [Connections](./connections.md).
+In case of MCLAG it's required to have a special connection with type `mclag-domain` that defines the peer and session
+links between switches. For more details, see [Connections](./connections.md).
 
 ## Servers
 
-It includes both control nodes and user's workload servers.
+Servers include both control nodes and user's workload servers.
 
 Control Node:
 

--- a/docs/user-guide/external.md
+++ b/docs/user-guide/external.md
@@ -4,7 +4,8 @@ Hedgehog Fabric uses Border Leaf concept to exchange VPC routes outside the Fabr
 `External Peering` feature allows to set up an external peering endpoint and to enforce several policies between
 internal and external endpoints.
 
->Hedgehog Fabric does not operate Edge side devices.
+!!! note
+    Hedgehog Fabric does not operate Edge side devices.
 
 ## Overview
 
@@ -12,7 +13,8 @@ Traffic exit from the Fabric is done on Border Leafs that are connected with Edg
 terminate l2vpn connections and distinguish VPC L3 routable traffic towards Edge device as well as to land VPC servers.
 Border Leafs (or Borders) can connect to several Edge devices.
 
->External Peering is only available on the switch devices that are capable for sub-interfaces.
+!!! note
+    External Peering is only available on the switch devices that are capable for sub-interfaces.
 
 ### Connect Border Leaf to Edge device
 
@@ -229,7 +231,8 @@ spec:
 ```
 ### Example Edge side BGP configuration based on SONiC OS
 
-> **_NOTE:_** Hedgehog does not recommend using following configuration for production. It's just as example of Edge Peer config
+!!! warning
+    Hedgehog does not recommend using following configuration for production. It's just as example of Edge Peer config
 
 Interface config
 ```yaml

--- a/docs/user-guide/harvester.md
+++ b/docs/user-guide/harvester.md
@@ -1,23 +1,24 @@
 # Using VPCs with Harvester
 
-It's an example of how Hedgehog Fabric can be used with Harvester or any hypervisor on the servers connected to Fabric.
-It assumes that you have already installed Fabric and have some servers running Harvester attached to it.
+This section contains an example of how Hedgehog Fabric can be used with Harvester or any hypervisor on the servers
+connected to Fabric. It assumes that you have already installed Fabric and have some servers running Harvester attached
+to it.
 
-You'll need to define `Server` object per each server running Harvester and `Connection` object per each server
+You need to define a `Server` object for each server running Harvester and a `Connection` object for each server
 connection to the switches.
 
-You can have multiple VPCs created and attached to the `Connections` to this servers to make them available to the VMs
-in Harvester or any other hypervisor.
+You can have multiple VPCs created and attached to the `Connections` to the servers to make them available to the VMs in
+Harvester or any other hypervisor.
 
 ## Configure Harvester
 
 ### Add a Cluster Network
 
-From the "Cluster Network/Confg" side menu. Create a new Cluster Network.
+From the "Cluster Networks/Configs" side menu, create a new Cluster Network.
 
 ![Harvester Cluster Network](./harvester-cluster-network.png)
 
-Here is what the CRD looks like cleaned up:
+Here is a cleaned-up version of what the CRD looks like:
 
 ```yaml
 apiVersion: network.harvesterhci.io/v1beta1
@@ -28,11 +29,11 @@ metadata:
 
 ### Add a Network Config
 
-By clicking "Create Network Confg". Add your connections and select bonding type.
+Click "Create Network Config". Add your connections and select the bonding type.
 
 ![Harvester Network Config](./harvester-network-config.png)
 
-The resulting cleaned up CRD:
+The resulting CRD (cleaned up) looks like the following:
 
 ```yaml
 apiVersion: network.harvesterhci.io/v1beta1
@@ -56,12 +57,12 @@ spec:
 
 ### Add VLAN based VM Networks
 
-Browse over to "VM Networks" and add one for each Vlan you want to support, assigning them to the cluster network.
+Browse over to "VM Networks" and add one network for each VLAN you want to support. Assign them to the cluster network.
 
 ![Harvester VM Networks](./harvester-vm-networks.png)
 ![Harvester VM Network Details](./harvester-vm-network-details.png)
 
-Here is what the CRDs will look like for both vlans:
+Here is what the CRDs will look like for both VLANs:
 
 ```yaml
 apiVersion: k8s.cni.cncf.io/v1
@@ -98,4 +99,4 @@ spec:
 
 ### Using the VPCs
 
-Now you can choose created VM Networks when creating a VM in Harvester and have them created as part of the VPC.
+Now you can choose the new VM Networks when creating a VM in Harvester, and have them created as part of the VPC.

--- a/docs/user-guide/overview.md
+++ b/docs/user-guide/overview.md
@@ -1,3 +1,3 @@
 # Overview
 
-The chapter is intended to give an overview of the main features of the Hedgehog Fabric and their usage.
+This chapter gives an overview of the main features of Hedgehog Fabric and their usage.

--- a/docs/user-guide/shrink-expand.md
+++ b/docs/user-guide/shrink-expand.md
@@ -1,33 +1,45 @@
 # Fabric Shrink/Expand
 
-This article gives brief overview of how to add or remove switches within the fabric using Hedgehog Fabric API and manage connections between them.
+This section provides a brief overview of how to add or remove switches within the fabric using Hedgehog Fabric API, and
+how to manage connections between them.
 
-Manipulating API objects done with assumption that target devices are correctly cabeled and connected.
+Manipulating API objects is done with the assumption that target devices are correctly cabeled and connected.
 
-This article operates terms that can be found in [Hedgehog Concepts](../concepts/overview.md), [User Guide](overview.md) documentation and [Fabric API](../reference/api.md) reference.
+This article operates terms that can be found in the [Hedgehog Concepts](../concepts/overview.md), the [User
+Guide](overview.md) documentation, and the [Fabric API](../reference/api.md) reference.
 
-### Add switch to the existing fabric
+### Add a switch to the existing fabric
 
-For every switch to be added into the Hedgehog fabric it should have a corresponding `Switch` object. Example can be found in [User Guilde](devices.md).
-
-!!! note
-    If the`Switch` will be used in `ESLAG` or `MCLAG` groups, appropriate groups should exist. Redundancy groups should be specified in the `Switch` object before creation.
-
-After the `Switch` object is created, dedicated device `Connections` can be defined and created. Based on the `Switch` role given to the device types of connections may be different. Please refer to [Connections section](connections.md).
+To be added to the Hedgehog Fabric, a switch should have a corresponding `Switch` object. An example on how to define
+this object is available in the [User Guilde](devices.md).
 
 !!! note
-    If switch is facing control node connection on the front-panel port, such switch port should be described in `Management` connection
+    If the`Switch` will be used in `ESLAG` or `MCLAG` groups, appropriate groups should exist. Redundancy groups should
+    be specified in the `Switch` object before creation.
+
+After the `Switch` object has been created, you can define and create dedicated device `Connections`. The types of the
+connections may differ based on the `Switch` role given to the device. For more details, refer to [Connections
+section](connections.md).
 
 !!! note
-    Switch device should be booted in `ONIE` or `HONIE` Installation mode to install SONiC OS and configure Fabric agent
+    If the switch is facing a Control Node Connection on the front-panel port, the switch port should be described in a
+    `Management` connection.
 
-### Remove switch from the existing fabric
+!!! note
+    Switch devices should be booted in `ONIE` or `HONIE` installation mode to install SONiC OS and configure the Fabric
+    Agent.
 
-If the switch has to be decommissioned or removed there are several preparation steps before disabling it from the Fabric.
+### Remove a switch from the existing fabric
+
+Before you decommission a switch from the Hedgehog Fabric, several preparation steps are necessary.
 
 !!! warning
-    Currently the `Wiring` diagram used for initial deployment is saved in `/var/lib/rancher/k3s/server/manifests/hh-wiring.yaml` on the `Control` node. Fabric will sustain objects within the original wiring diagram. In order to remove any of the object that is described in this chapter, dedicated API object should be first removed from this file. It's recommended to reapply `hh-wiring.yaml` after changing it's internals.
+    Currently the `Wiring` diagram used for initial deployment is saved in
+    `/var/lib/rancher/k3s/server/manifests/hh-wiring.yaml` on the `Control` node. Fabric will sustain objects within the
+    original wiring diagram. In order to remove any object, first remove the dedicated API objects from this file. It is
+    recommended to reapply `hh-wiring.yaml` after changing its internals.
 
-- If the `Switch` is a `Leaf` switch (including `Mixed` and `Border` leaf configuration) all `VPCAttachments` bound to all switches `Connections` must be removed first. If the `Switch` was used for `ExternalPeering` all `ExternalAttachment` object that are bound to `Connections` of the `Switch` must be removed.
--  All connections of the `Switch` must be removed.
-- `Switch` and `Agent` object can be removed.
+* If the `Switch` is a `Leaf` switch (including `Mixed` and `Border` leaf configurations), remove all `VPCAttachments` bound to all switches `Connections`.
+* If the `Switch` was used for `ExternalPeering`, remove all `ExternalAttachment` objects that are bound to the `Connections` of the `Switch`.
+* Remove all connections of the `Switch`.
+* At last, remove the `Switch` and `Agent` objects.

--- a/docs/user-guide/shrink-expand.md
+++ b/docs/user-guide/shrink-expand.md
@@ -10,20 +10,23 @@ This article operates terms that can be found in [Hedgehog Concepts](../concepts
 
 For every switch to be added into the Hedgehog fabric it should have a corresponding `Switch` object. Example can be found in [User Guilde](devices.md).
 
->If the`Switch` will be used in `ESLAG` or `MCLAG` groups, appropriate groups should exist. Redundancy groups should be specified in the `Switch` object before creation.
+!!! note
+    If the`Switch` will be used in `ESLAG` or `MCLAG` groups, appropriate groups should exist. Redundancy groups should be specified in the `Switch` object before creation.
 
 After the `Switch` object is created, dedicated device `Connections` can be defined and created. Based on the `Switch` role given to the device types of connections may be different. Please refer to [Connections section](connections.md).
 
->If switch is facing control node connection on the front-panel port, such switch port should be described in `Management` connection
+!!! note
+    If switch is facing control node connection on the front-panel port, such switch port should be described in `Management` connection
 
->Switch device should be booted in `ONIE` or `HONIE` Installation mode to install SONiC OS and configure Fabric agent
+!!! note
+    Switch device should be booted in `ONIE` or `HONIE` Installation mode to install SONiC OS and configure Fabric agent
 
 ### Remove switch from the existing fabric
 
 If the switch has to be decommissioned or removed there are several preparation steps before disabling it from the Fabric.
 
-> [!WARNING]
-> Currently the `Wiring` diagram used for initial deployment is saved in `/var/lib/rancher/k3s/server/manifests/hh-wiring.yaml` on the `Control` node. Fabric will sustain objects within the original wiring diagram. In order to remove any of the object that is described in this chapter, dedicated API object should be first removed from this file. It's recommended to reapply `hh-wiring.yaml` after changing it's internals.
+!!! warning
+    Currently the `Wiring` diagram used for initial deployment is saved in `/var/lib/rancher/k3s/server/manifests/hh-wiring.yaml` on the `Control` node. Fabric will sustain objects within the original wiring diagram. In order to remove any of the object that is described in this chapter, dedicated API object should be first removed from this file. It's recommended to reapply `hh-wiring.yaml` after changing it's internals.
 
 - If the `Switch` is a `Leaf` switch (including `Mixed` and `Border` leaf configuration) all `VPCAttachments` bound to all switches `Connections` must be removed first. If the `Switch` was used for `ExternalPeering` all `ExternalAttachment` object that are bound to `Connections` of the `Switch` must be removed.
 -  All connections of the `Switch` must be removed.

--- a/docs/user-guide/vpcs.md
+++ b/docs/user-guide/vpcs.md
@@ -2,8 +2,8 @@
 
 ## VPC
 
-Virtual Private Cloud, similar to the public cloud VPC it provides an isolated private network for the resources with
-support for multiple subnets each with user-provided VLANs and on-demand DHCP.
+A Virtual Private Cloud (VPC) is similar to a public cloud VPC. It provides an isolated private network for the
+resources with support for multiple subnets, each with user-provided VLANs and on-demand DHCP.
 
 ```yaml
 apiVersion: vpc.githedgehog.com/v1alpha2
@@ -25,12 +25,12 @@ spec:
         range: # Optionally, start/end range could be specified
           start: 10.10.1.10
           end: 10.10.1.99
-          pxeURL: tftp://10.10.10.99/bootfilename # PXEURL (optional) to identify the pxe server to use to boot hosts, http query strings are not supported
+          pxeURL: tftp://10.10.10.99/bootfilename # PXEURL (optional) to identify the PXE server to use to boot hosts; HTTP query strings are not supported
       subnet: 10.10.1.0/24 # User-defined subnet from ipv4 namespace
       gateway: 10.10.1.1 # User-defined gateway (optional, default is .1)
-      vlan: "1001" # User-defined VLAN from vlan namespace
+      vlan: "1001" # User-defined VLAN from VLAN namespace
       isolated: true # Makes subnet isolated from other subnets within the VPC (doesn't affect VPC peering)
-      restricted: true # Makes all hosts in the subnet to be isolated from each other
+      restricted: true # Causes all hosts in the subnet to be isolated from each other
 
     thrird-party-dhcp: # Another subnet
       dhcp:
@@ -49,32 +49,34 @@ spec:
 
 ### Isolated and restricted subnets, permit lists
 
-Subnets could be isolated and restricted with ability to define permit lists to allow communication between specific
+Subnets can be isolated and restricted, with the ability to define permit lists to allow communication between specific
 isolated subnets. The permit list is applied on top of the isolated flag and doesn't affect VPC peering.
 
-Isolated subnet means that the subnet has no connectivity with other subnets within the VPC, but it could still be
+_Isolated subnet_ means that the subnet has no connectivity with other subnets within the VPC, but it could still be
 allowed by permit lists.
 
-Restricted subnet means that all hosts in the subnet are isolated from each other within the subnet.
+_Restricted subnet_ means that all hosts in the subnet are isolated from each other within the subnet.
 
-Permit lists are defined as a list of subnets that could communicate to each other.
+A Permit list is defined as a list of subnets that could communicate with each other.
 
 ### Third-party DHCP server
 
-In case if you're using thirt-party DHCP server by configuring `spec.subnets.<subnet>.dhcp.relay` additional information
-will be added to the DHCP packet it forwards to the DHCP server to make it possible to identify the VPC and subnet. The
-information is added under the RelayAgentInfo option(82) on the DHCP packet. The relay sets two suboptions in the packet
+In case you use a third-party DHCP server by configuring `spec.subnets.<subnet>.dhcp.relay`, additional information is
+added to the DHCP packet forwarded to the DHCP server to make it possible to identify the VPC and subnet. This
+information is added under the RelayAgentInfo (option 82) in the DHCP packet. The relay sets two suboptions in the
+packet:
 
-* VirtualSubnetSelection -- (suboption 151) is populated with the VRF which uniquely idenitifies a VPC on the Hedgehog
-  Fabric and will be in `VrfV<VPC-name>` format, e.g. `VrfVvpc-1` for VPC named `vpc-1` in the Fabric API
-* CircuitID -- (suboption 1) identifies the VLAN which together with VRF (VPC) name maps to a specific VPC subnet
+* _VirtualSubnetSelection_ (suboption 151) is populated with the VRF which uniquely identifies a VPC on the Hedgehog
+  Fabric and will be in `VrfV<VPC-name>` format, for example `VrfVvpc-1` for a VPC named `vpc-1` in the Fabric API.
+* _CircuitID_ (suboption 1) identifies the VLAN which, together with the VRF (VPC) name, maps to a specific VPC subnet.
 
 ## VPCAttachment
 
-Represents a specific VPC subnet assignment to the `Connection` object which means exact server port to a VPC binding.
+A VPCAttachment represents a specific VPC subnet assignment to the `Connection` object which means a binding between an
+exact server port and a VPC.
 It basically leads to the VPC being available on the specific server port(s) on a subnet VLAN.
 
-VPC could be attached to a switch which is a part of the VLAN namespace used by the VPC.
+VPC could be attached to a switch that is part of the VLAN namespace used by the VPC.
 
 ```yaml
 apiVersion: vpc.githedgehog.com/v1alpha2
@@ -90,10 +92,10 @@ spec:
 
 ## VPCPeering
 
-It enables VPC to VPC connectivity. There are tw o types of VPC peering:
+A VPCPeering enables VPC-to-VPC connectivity. There are two types of VPC peering:
 
-* Local - peering is implemented on the same switches where VPCs are attached
-* Remote - peering is implemented on the border/mixed leafs defined by the `SwitchGroup` object
+* Local: peering is implemented on the same switches where VPCs are attached
+* Remote: peering is implemented on the border/mixed leaves defined by the `SwitchGroup` object
 
 VPC peering is only possible between VPCs attached to the same IPv4 namespace.
 
@@ -107,8 +109,8 @@ metadata:
   namespace: default
 spec:
   permit: # Defines a pair of VPCs to peer
-  - vpc-1: {} # meaning all subnets of two VPCs will be able to communicate to each other
-    vpc-2: {} # see "Subnet filtering" for more advanced configuration
+  - vpc-1: {} # Meaning all subnets of two VPCs will be able to communicate with each other
+    vpc-2: {} # See "Subnet filtering" for more advanced configuration
 ```
 
 ### Remote VPC peering
@@ -123,7 +125,7 @@ spec:
   permit:
   - vpc-1: {}
     vpc-2: {}
-  remote: border # indicates a switch group to implement the peering on
+  remote: border # Indicates a switch group to implement the peering on
 ```
 
 ### Subnet filtering
@@ -152,8 +154,8 @@ spec:
 
 ## IPv4Namespace
 
-Defines non-overlapping VLAN ranges for attaching servers. Each switch belongs to a list of VLAN namespaces with
-non-overlapping VLAN ranges.
+An IPv4Namespace defines non-overlapping VLAN ranges for attaching servers. Each switch belongs to a list of VLAN
+namespaces with non-overlapping VLAN ranges.
 
 ```yaml
 apiVersion: vpc.githedgehog.com/v1alpha2
@@ -168,7 +170,7 @@ spec:
 
 ## VLANNamespace
 
-Defines non-overlapping IPv4 ranges for VPC subnets. Each VPC belongs to a specific IPv4 namespace.
+A VLANNamespace defines non-overlapping IPv4 ranges for VPC subnets. Each VPC belongs to a specific IPv4 namespace.
 
 ```yaml
 apiVersion: wiring.githedgehog.com/v1alpha2

--- a/docs/vlab/demo.md
+++ b/docs/vlab/demo.md
@@ -69,7 +69,7 @@ You can create and attach VPCs to the VMs using the `kubectl fabric vpc` command
 using the kubeconfig. For example, run following commands to create a 2 VPCs with a single subnet each, DHCP server
 enabled with optional IP address range start defined and attach them to some test servers:
 
-```bash
+```console
 core@control-1 ~ $ kubectl get conn | grep server
 server-01--mclag--leaf-01--leaf-02   mclag          5h13m
 server-02--mclag--leaf-01--leaf-02   mclag          5h13m
@@ -93,7 +93,7 @@ core@control-1 ~ $ kubectl fabric vpc attach --vpc-subnet vpc-2/default --connec
 
 VPC subnet should belong to some IPv4Namespace, default one in the VLAB is `10.0.0.0/16`:
 
-```bash
+```console
 core@control-1 ~ $ kubectl get ipns
 NAME      SUBNETS           AGE
 default   ["10.0.0.0/16"]   5h14m
@@ -102,7 +102,7 @@ default   ["10.0.0.0/16"]   5h14m
 After you created VPCs and VPCAttachments, you can check the status of the agents to make sure that requested
 configuration was apploed to the switches:
 
-```bash
+```console
 core@control-1 ~ $ kubectl get agents
 NAME       ROLE          DESCR           APPLIED   APPLIEDG   CURRENTG   VERSION
 leaf-01    server-leaf   VS-01 MCLAG 1   2m2s      5          5          v0.23.0
@@ -124,7 +124,7 @@ preinstalled by Fabricator on test servers.
 
 For server-01:
 
-```bash
+```console
 core@server-01 ~ $ hhnet cleanup
 core@server-01 ~ $ hhnet bond 1001 enp2s1 enp2s2
 10.0.1.10/24
@@ -148,7 +148,7 @@ core@server-01 ~ $ ip a
 
 And for server-02:
 
-```bash
+```console
 core@server-02 ~ $ hhnet cleanup
 core@server-02 ~ $ hhnet bond 1002 enp2s1 enp2s2
 10.0.2.10/24
@@ -174,7 +174,7 @@ core@server-02 ~ $ ip a
 
 You can test connectivity between the servers before peering the switches using `ping` command:
 
-```bash
+```console
 core@server-01 ~ $ ping 10.0.2.10
 PING 10.0.2.10 (10.0.2.10) 56(84) bytes of data.
 From 10.0.1.1 icmp_seq=1 Destination Net Unreachable
@@ -185,7 +185,7 @@ From 10.0.1.1 icmp_seq=3 Destination Net Unreachable
 3 packets transmitted, 0 received, +3 errors, 100% packet loss, time 2003ms
 ```
 
-```bash
+```console
 core@server-02 ~ $ ping 10.0.1.10
 PING 10.0.1.10 (10.0.1.10) 56(84) bytes of data.
 From 10.0.2.1 icmp_seq=1 Destination Net Unreachable
@@ -200,7 +200,7 @@ From 10.0.2.1 icmp_seq=3 Destination Net Unreachable
 
 To enable connectivity between the VPCs, you need to peer them using `kubectl fabric vpc peer` command:
 
-```bash
+```console
 core@control-1 ~ $ kubectl fabric vpc peer --vpc vpc-1 --vpc vpc-2
 07:04:58 INF VPCPeering created name=vpc-1--vpc-2
 ```
@@ -208,7 +208,7 @@ core@control-1 ~ $ kubectl fabric vpc peer --vpc vpc-1 --vpc vpc-2
 Make sure to wait until the peering is applied to the switches using `kubectl get agents` command. After that you can
 test connectivity between the servers again:
 
-```bash
+```console
 core@server-01 ~ $ ping 10.0.2.10
 PING 10.0.2.10 (10.0.2.10) 56(84) bytes of data.
 64 bytes from 10.0.2.10: icmp_seq=1 ttl=62 time=6.25 ms
@@ -220,7 +220,7 @@ PING 10.0.2.10 (10.0.2.10) 56(84) bytes of data.
 rtt min/avg/max/mdev = 6.245/7.481/8.601/0.965 ms
 ```
 
-```bash
+```console
 core@server-02 ~ $ ping 10.0.1.10
 PING 10.0.1.10 (10.0.1.10) 56(84) bytes of data.
 64 bytes from 10.0.1.10: icmp_seq=1 ttl=62 time=5.44 ms
@@ -235,12 +235,12 @@ rtt min/avg/max/mdev = 4.489/5.529/6.656/0.886 ms
 If you will delete VPC peering using command following command and wait for the agent to apply configuration on the
 switches, you will see that connectivity will be lost again:
 
-```bash
+```console
 core@control-1 ~ $ kubectl delete vpcpeering/vpc-1--vpc-2
 vpcpeering.vpc.githedgehog.com "vpc-1--vpc-2" deleted
 ```
 
-```bash
+```console
 core@server-01 ~ $ ping 10.0.2.10
 PING 10.0.2.10 (10.0.2.10) 56(84) bytes of data.
 From 10.0.1.1 icmp_seq=1 Destination Net Unreachable
@@ -255,7 +255,7 @@ From 10.0.1.1 icmp_seq=3 Destination Net Unreachable
     You can see duplicate packets in the output of the `ping` command between some of the servers. This is expected
     behavior and is caused by the limitations in the VLAB environment.
 
-    ```yaml
+    ```console
     core@server-01 ~ $ ping 10.0.5.10
     PING 10.0.5.10 (10.0.5.10) 56(84) bytes of data.
     64 bytes from 10.0.5.10: icmp_seq=1 ttl=62 time=9.58 ms
@@ -274,7 +274,7 @@ From 10.0.1.1 icmp_seq=3 Destination Net Unreachable
 
 First of all, we'll need to make sure that we have a second IPv4Namespace with the same subnet as default one:
 
-```bash
+```console
 core@control-1 ~ $ kubectl get ipns
 NAME      SUBNETS           AGE
 default   ["10.0.0.0/16"]   24m
@@ -303,7 +303,7 @@ Let's assume that `vpc-1` already exists and is attached to `server-01` (see [Cr
 Now we can create `vpc-3` with the same subnet as `vpc-1` (but in the different IPv4Namespace) and attach it to the
 `server-03`:
 
-```bash
+```console
 core@control-1 ~ $ cat <<EOF > vpc-3.yaml
 apiVersion: vpc.githedgehog.com/v1alpha2
 kind: VPC

--- a/docs/vlab/demo.md
+++ b/docs/vlab/demo.md
@@ -1,17 +1,17 @@
 # Demo on VLAB
 
-Goal of this demo is to show how to use VPCs, attach and peer them and test connectivity between the servers. Examples
-are based on the default VLAB topology.
+The goal of this demo is to show how to use VPCs, attach and peer them and run test connectivity between the servers.
+Examples are based on the default VLAB topology.
 
 You can find instructions on how to setup VLAB in the [Overview](overview.md) and [Running VLAB](running.md) sections.
 
 ## Default topology
 
-The default topology is Spine-Leaf with 2 spines, 2 MCLAG leafs and 1 non-MCLAG leaf.
-Optionally, you can choose to run default Collapsed Core topology using `--fabric-mode collapsed-core`
-(or `-m collapsed-core`) flag which only conisists of 2 switches.
+The default topology is Spine-Leaf with 2 spines, 2 MCLAG leaves and 1 non-MCLAG leaf. Optionally, you can choose to run
+the default Collapsed Core topology using flag `--fabric-mode collapsed-core` (or `-m collapsed-core`) which only
+consists of 2 switches.
 
-For more details on the customizing topologies see [Running VLAB](running.md) section.
+For more details on customizing topologies see the [Running VLAB](running.md) section.
 
 In the default topology, the following Control Node and Switch VMs are created:
 
@@ -35,13 +35,14 @@ graph TD
     S2 --> L3
 ```
 
-As well as test servers:
+As well as the following test servers:
 
 ```mermaid
 graph TD
     L1[MCLAG Leaf 1]
     L2[MCLAG Leaf 2]
     L3[Leaf 3]
+    L4[Leaf 4]
 
     TS1[Test Server 1]
     TS2[Test Server 2]
@@ -65,9 +66,9 @@ graph TD
 
 ## Creating and attaching VPCs
 
-You can create and attach VPCs to the VMs using the `kubectl fabric vpc` command on control node or outside of cluster
-using the kubeconfig. For example, run following commands to create a 2 VPCs with a single subnet each, DHCP server
-enabled with optional IP address range start defined and attach them to some test servers:
+You can create and attach VPCs to the VMs using the `kubectl fabric vpc` command on the Control Node or outside of the
+cluster using the kubeconfig. For example, run the following commands to create 2 VPCs with a single subnet each, a DHCP
+server enabled with its optional IP address range start defined, and to attach them to some of the test servers:
 
 ```console
 core@control-1 ~ $ kubectl get conn | grep server
@@ -91,7 +92,7 @@ core@control-1 ~ $ kubectl fabric vpc attach --vpc-subnet vpc-2/default --connec
 06:49:34 INF VPCAttachment created name=vpc-2--default--server-02--mclag--leaf-01--leaf-02
 ```
 
-VPC subnet should belong to some IPv4Namespace, default one in the VLAB is `10.0.0.0/16`:
+The VPC subnet should belong to an IPv4Namespace, the default one in the VLAB is `10.0.0.0/16`:
 
 ```console
 core@control-1 ~ $ kubectl get ipns
@@ -99,8 +100,8 @@ NAME      SUBNETS           AGE
 default   ["10.0.0.0/16"]   5h14m
 ```
 
-After you created VPCs and VPCAttachments, you can check the status of the agents to make sure that requested
-configuration was apploed to the switches:
+After you created the VPCs and VPCAttachments, you can check the status of the agents to make sure that the requested
+configuration was applied to the switches:
 
 ```console
 core@control-1 ~ $ kubectl get agents
@@ -112,17 +113,18 @@ spine-01   spine         VS-04           16m       3          3          v0.23.0
 spine-02   spine         VS-05           18m       4          4          v0.23.0
 ```
 
-As you can see columns `APPLIED` and `APPLIEDG` are equal which means that requested configuration was applied.
+In this example, the values in columns `APPLIED` and `APPLIEDG` are equal which means that the requested configuration
+has been applied.
 
 ## Setting up networking on test servers
 
-You can use `hhfab vlab ssh` on the host to ssh into the test servers and configure networking there. For example, for
-both server-01 (MCLAG attached to both leaf-01 and leaf-02) we need to configure bond with a vlan on top of it and for
-the server-05 (single-homed unbundled attached to leaf-03) we need to configure just a vlan and they both will get an
-IP address from the DHCP server. You can use `ip` command to configure networking on the servers or use little helper
-preinstalled by Fabricator on test servers.
+You can use `hhfab vlab ssh` on the host to SSH into the test servers and configure networking there. For example, for
+both `server-01` (MCLAG attached to both `leaf-01` and `leaf-02`) we need to configure a bond with a VLAN on top of it
+and for the `server-05` (single-homed unbundled attached to `leaf-03`) we need to configure just a VLAn and they both
+will get an IP address from the DHCP server. You can use the `ip` command to configure networking on the servers or use
+the little helper preinstalled by Fabricator on test servers.
 
-For server-01:
+For `server-01`:
 
 ```console
 core@server-01 ~ $ hhnet cleanup
@@ -146,7 +148,7 @@ core@server-01 ~ $ ip a
        valid_lft forever preferred_lft forever
 ```
 
-And for server-02:
+And for `server-02`:
 
 ```console
 core@server-02 ~ $ hhnet cleanup
@@ -172,7 +174,7 @@ core@server-02 ~ $ ip a
 
 ## Testing connectivity before peering
 
-You can test connectivity between the servers before peering the switches using `ping` command:
+You can test connectivity between the servers before peering the switches using the `ping` command:
 
 ```console
 core@server-01 ~ $ ping 10.0.2.10
@@ -198,14 +200,14 @@ From 10.0.2.1 icmp_seq=3 Destination Net Unreachable
 
 ## Peering VPCs and testing connectivity
 
-To enable connectivity between the VPCs, you need to peer them using `kubectl fabric vpc peer` command:
+To enable connectivity between the VPCs, peer them using `kubectl fabric vpc peer`:
 
 ```console
 core@control-1 ~ $ kubectl fabric vpc peer --vpc vpc-1 --vpc vpc-2
 07:04:58 INF VPCPeering created name=vpc-1--vpc-2
 ```
 
-Make sure to wait until the peering is applied to the switches using `kubectl get agents` command. After that you can
+Make sure to wait until the peering is applied to the switches using `kubectl get agents` command. After that, you can
 test connectivity between the servers again:
 
 ```console
@@ -232,8 +234,8 @@ PING 10.0.1.10 (10.0.1.10) 56(84) bytes of data.
 rtt min/avg/max/mdev = 4.489/5.529/6.656/0.886 ms
 ```
 
-If you will delete VPC peering using command following command and wait for the agent to apply configuration on the
-switches, you will see that connectivity will be lost again:
+If you delete the VPC peering with `kubectl delete` applied to the relevant object and wait for the agent to apply the
+configuration on the switches, you can observe that connectivity is lost again:
 
 ```console
 core@control-1 ~ $ kubectl delete vpcpeering/vpc-1--vpc-2
@@ -272,7 +274,7 @@ From 10.0.1.1 icmp_seq=3 Destination Net Unreachable
 
 ## Using VPCs with overlapping subnets
 
-First of all, we'll need to make sure that we have a second IPv4Namespace with the same subnet as default one:
+First, create a second IPv4Namespace with the same subnet as the default one:
 
 ```console
 core@control-1 ~ $ kubectl get ipns
@@ -326,5 +328,6 @@ EOF
 core@control-1 ~ $ kubectl apply -f vpc-3.yaml
 ```
 
-At that point you can setup networking on the `server-03` same as for `server-01` and `server-02` in a previous sections
-and see that we have now `server-01` and `server-03` with the IP addresses from the same subnets.
+At that point you can setup networking on `server-03` the same as you did for `server-01` and `server-02` in
+[a previous section](#setting-up-networking-on-test-servers). Once you have configured networking, `server-01` and
+`server-03` have IP addresses from the same subnets.

--- a/docs/vlab/overview.md
+++ b/docs/vlab/overview.md
@@ -65,7 +65,7 @@ kvm-ok
 
 Good output of the `kvm-ok` command should look like this:
 
-```
+```console
 ubuntu@docs:~$ kvm-ok
 INFO: /dev/kvm exists
 KVM acceleration can be used

--- a/docs/vlab/overview.md
+++ b/docs/vlab/overview.md
@@ -1,17 +1,17 @@
 # Overview
 
 It's possible to run Hedgehog Fabric in a fully virtual environment using QEMU/KVM and SONiC Virtual Switch (VS). It's
-a great way to try out Fabric and learn about its looka and feel, API, capabilities and etc. It's not suitable for any
-data plane or performance testing as well as not for production use.
+a great way to try out Fabric and learn about its look and feel, API, and capabilities. It's not suitable for any
+data plane or performance testing, or for production use.
 
-In the VLAB all switches will start as an empty VMs with only ONIE image on them and will go through the whole
-discovery, boot and installation process like on the real hardware.
+In the VLAB all switches start as empty VMs with only the ONIE image on them, and they go through the whole discovery,
+boot and installation process like on real hardware.
 
 ## Overview
 
-The `hhfab` CLI provides a special command `vlab` to manage the virtual labs. It allows to run set of virtual machines
-to simulate the Fabric infrastructure including control node, switches, test servers and automatically runs installer
-to get Fabric up and running.
+The `hhfab` CLI provides a special command `vlab` to manage the virtual labs. It allows you to run sets of virtual
+machines to simulate the Fabric infrastructure including control node, switches, test servers and it automatically runs
+the installer to get Fabric up and running.
 
 You can find more information about getting `hhfab` in the [download](../getting-started/download.md) section.
 
@@ -20,12 +20,12 @@ You can find more information about getting `hhfab` in the [download](../getting
 Currently, it's only tested on Ubuntu 22.04 LTS, but should work on any Linux distribution with QEMU/KVM support and fairly
 up-to-date packages.
 
-Following packages needs to be installed: `qemu-kvm swtpm-tools tpm2-tools socat` and docker will be required to login
-into OCI registry.
+The following packages needs to be installed: `qemu-kvm swtpm-tools tpm2-tools socat`. Docker is also required, to login
+into the OCI registry.
 
-By default, VLAB topology is Spine-Leaf with 2 spines, 2 MCLAG leafs and 1 non-MCLAG leaf. Optionally, you can choose
-to run default Collapsed Core topology using `--fabric-mode collapsed-core` (or `-m collapsed-core`) flag which only
-conisists of 2 switches.
+By default, the VLAB topology is Spine-Leaf with 2 spines, 2 MCLAG leaves and 1 non-MCLAG leaf. Optionally, you can
+choose to run the default Collapsed Core topology using flag `--fabric-mode collapsed-core` (or `-m collapsed-core`)
+which only consists of 2 switches.
 
 You can calculate the system requirements based on the allocated resources to the VMs using the following table:
 
@@ -35,12 +35,12 @@ You can calculate the system requirements based on the allocated resources to th
 | Test Server | 2 | 768MB | 10GB |
 | Switch | 4 | 5GB | 50GB |
 
-Which gives approximately the following requirements for the default topologies:
+These numbers give approximately the following requirements for the default topologies:
 
 * Spine-Leaf: 38 vCPUs, 36352 MB, 410 GB disk
 * Collapsed Core: 22 vCPUs, 19456 MB, 240 GB disk
 
-Usually, non of the VMs will reach 100% utilization of the allocated resources, but as a rule of thumb you should make
+Usually, none of the VMs will reach 100% utilization of the allocated resources, but as a rule of thumb you should make
 sure that you have at least allocated RAM and disk space for all VMs.
 
 NVMe SSD for VM disks is highly recommended.

--- a/docs/vlab/overview.md
+++ b/docs/vlab/overview.md
@@ -4,7 +4,7 @@ It's possible to run Hedgehog Fabric in a fully virtual environment using QEMU/K
 a great way to try out Fabric and learn about its looka and feel, API, capabilities and etc. It's not suitable for any
 data plane or performance testing as well as not for production use.
 
-In the VLAB all switches will start as an empty VMs with only ONiE image on them and will go through the whole
+In the VLAB all switches will start as an empty VMs with only ONIE image on them and will go through the whole
 discovery, boot and installation process like on the real hardware.
 
 ## Overview

--- a/docs/vlab/running.md
+++ b/docs/vlab/running.md
@@ -15,7 +15,7 @@ So, by default you'll get 2 spines, 2 MCLAG leafs and 1 non-MCLAG leaf with 2 fa
 leaf), 2 MCLAG peer links and 2 MCLAG session links as well as 2 loopbacks per leaf for implementing VPC Loopback
 workaround.
 
-```bash
+```console
 ubuntu@docs:~$ hhfab init -p vlab
 01:17:44 INF Generating wiring from gen flags
 01:17:44 INF Building wiring diagram fabricMode=spine-leaf chainControlLink=false controlLinksCount=0
@@ -29,7 +29,7 @@ ubuntu@docs:~$ hhfab init -p vlab
 
 Or if you want to run Collapsed Core topology with 2 MCLAG switches:
 
-```bash
+```console
 ubuntu@docs:~$ hhfab init -p vlab -m collapsed-core
 01:20:07 INF Generating wiring from gen flags
 01:20:07 INF Building wiring diagram fabricMode=collapsed-core chainControlLink=false controlLinksCount=0
@@ -42,7 +42,7 @@ ubuntu@docs:~$ hhfab init -p vlab -m collapsed-core
 
 Or you can run custom topology with 2 spines, 4 MCLAG leafs and 2 non-MCLAG leafs using flags:
 
-```bash
+```console
 ubuntu@docs:~$ hhfab init -p vlab --mclag-leafs-count 4 --orphan-leafs-count 2
 01:21:53 INF Generating wiring from gen flags
 01:21:53 INF Building wiring diagram fabricMode=spine-leaf chainControlLink=false controlLinksCount=0
@@ -63,7 +63,7 @@ all other prerequisites for running the VLAB.
 
 ## Build the installer and VLAB
 
-```bash
+```console
 ubuntu@docs:~$ hhfab build
 01:23:33 INF Building component=base
 01:23:33 WRN Attention! Development mode enabled - this is not secure! Default users and keys will be created.
@@ -105,7 +105,7 @@ to get VMs back up and running.
 
 ## Run VMs and installers
 
-```bash
+```console
 ubuntu@docs:~$ hhfab vlab up
 01:29:13 INF Starting VLAB server... basedir=.hhfab/vlab-vms vm-size="" dry-run=false
 01:29:13 INF VM id=0 name=control-1 type=control
@@ -195,7 +195,7 @@ provisioning and installing the software. After switches are installed you can u
 
 You can select device you want to access or pass the name using the `--vm` flag.
 
-```bash
+```console
 ubuntu@docs:~$ hhfab vlab ssh
 Use the arrow keys to navigate: ↓ ↑ → ←  and / toggles search
 SSH to VM:
@@ -225,7 +225,7 @@ switches to get installed.
 
 After switches are provisioned you will see something like this:
 
-```bash
+```console
 core@control-1 ~ $ kubectl get agents -o wide
 NAME       ROLE          DESCR           HWSKU                      ASIC   HEARTBEAT   APPLIED   APPLIEDG   CURRENTG   VERSION   SOFTWARE                ATTEMPT   ATTEMPTG   AGE
 leaf-01    server-leaf   VS-01 MCLAG 1   DellEMC-S5248f-P-25G-DPB   vs     30s         5m5s      4          4          v0.23.0   4.1.1-Enterprise_Base   5m5s      4          10m
@@ -251,7 +251,7 @@ using the Fabric in the [User Guide](../user-guide/overview.md), [Fabric API](..
 
  For example, to get the list of switches you can run:
 
-```bash
+```console
 core@control-1 ~ $ kubectl get switch
 NAME       ROLE          DESCR           GROUPS   LOCATIONUUID                           AGE
 leaf-01    server-leaf   VS-01 MCLAG 1            5e2ae08a-8ba9-599a-ae0f-58c17cbbac67   6h10m
@@ -263,7 +263,7 @@ spine-02   spine         VS-05                    96fbd4eb-53b5-5a4c-8d6a-bbc27d
 
 Similar for the servers:
 
-```bash
+```console
 core@control-1 ~ $ kubectl get server
 NAME        TYPE      DESCR                        AGE
 control-1   control   Control node                 6h10m
@@ -277,7 +277,7 @@ server-06             S-06 Bundled leaf-03         6h10m
 
 For connections:
 
-```bash
+```console
 core@control-1 ~ $ kubectl get connection
 NAME                                 TYPE           AGE
 control-1--mgmt--leaf-01             management     6h11m
@@ -305,7 +305,7 @@ spine-02--fabric--leaf-03            fabric         6h11m
 
 For IPv4 and VLAN namespaces:
 
-```bash
+```console
 core@control-1 ~ $ kubectl get ipns
 NAME      SUBNETS           AGE
 default   ["10.0.0.0/16"]   6h12m

--- a/docs/vlab/running.md
+++ b/docs/vlab/running.md
@@ -1,19 +1,19 @@
 # Running VLAB
 
-Please, make sure to follow prerequisites and check system requirements in the [VLAB Overview](overview.md) section
+Make sure to follow the prerequisites and check system requirements in the [VLAB Overview](overview.md) section
 before running VLAB.
 
 ## Initialize VLAB
 
-As a first step you need to initialize Fabricator for the VLAB by running `hhfab init --preset vlab` (or `-p vlab`). It
-supports a lot of customization options which you can find by adding `--help` to the command. If you want to tune the
-topology used for the VLAB you can use `--fabric-mode` (or `-m`) flag to choose between `spine-leaf` (default) and
-`collapsed-core` topologies as well as you can configure the number of spines, leafs, connections and etc. For example,
-`--spines-count` and `--mclag-leafs-count` flags allows to set number of spines and MCLAG leafs respectively.
+First, initialize Fabricator for the VLAB by running `hhfab init --preset vlab` (or `-p vlab`). This command supports
+several customization options that are listed in the output of `hhfab init --help`. To tune the topology used for the
+VLAB, you can use the `--fabric-mode` (or `-m`) flag to choose between `spine-leaf` (default) and `collapsed-core`
+topologies. You can also configure the number of spines, leafs, connections, and so on. For example, flags
+`--spines-count` and `--mclag-leafs-count` allow you to set the number of spines and MCLAG leaves, respectively.
 
-So, by default you'll get 2 spines, 2 MCLAG leafs and 1 non-MCLAG leaf with 2 fabric connections (between each spine and
-leaf), 2 MCLAG peer links and 2 MCLAG session links as well as 2 loopbacks per leaf for implementing VPC Loopback
-workaround.
+By default, the command creates 2 spines, 2 MCLAG leaves and 1 non-MCLAG leaf with 2 fabric connections (between each
+spine and leaf), 2 MCLAG peer links and 2 MCLAG session links as well as 2 loopbacks per leaf for implementing VPC
+Loopback workaround.
 
 ```console
 ubuntu@docs:~$ hhfab init -p vlab
@@ -40,7 +40,7 @@ ubuntu@docs:~$ hhfab init -p vlab -m collapsed-core
 01:20:07 INF Initialized preset=vlab fabricMode=collapsed-core config=.hhfab/config.yaml wiring=.hhfab/wiring.yaml
 ```
 
-Or you can run custom topology with 2 spines, 4 MCLAG leafs and 2 non-MCLAG leafs using flags:
+Or you can run custom topology with 2 spines, 4 MCLAG leaves and 2 non-MCLAG leaves using flags:
 
 ```console
 ubuntu@docs:~$ hhfab init -p vlab --mclag-leafs-count 4 --orphan-leafs-count 2
@@ -54,12 +54,12 @@ ubuntu@docs:~$ hhfab init -p vlab --mclag-leafs-count 4 --orphan-leafs-count 2
 01:21:53 INF Initialized preset=vlab fabricMode=spine-leaf config=.hhfab/config.yaml wiring=.hhfab/wiring.yaml
 ```
 
-Additionally, you can do extra Fabric configuration using flags on `init` command or by passing config file, more
-information about it is available in the [Fabric Configuration](../install-upgrade/config.md) section.
+Additionally, you can pass extra Fabric configuration items using flags on `init` command or by passing a configuration
+file. For more information, refer to the [Fabric Configuration](../install-upgrade/config.md) section.
 
-Once you have initialized the VLAB you need to download all artifacts and build the installer using `hhfab build`
-command. It will automatically download all required artifacts from the OCI registry and build the installer as well as
-all other prerequisites for running the VLAB.
+Once you have initialized the VLAB, download the artifacts and build the installer using `hhfab build`. This command
+automatically downloads all required artifacts from the OCI registry and builds the installer and all other
+prerequisites for running the VLAB.
 
 ## Build the installer and VLAB
 
@@ -98,10 +98,10 @@ Copying k9s  57.75 MiB / 57.75 MiB   ⠼   0.00 b/s done
 01:25:45 INF Packing done took=5.67007384s
 ```
 
-As soon as it's done you can run the VLAB using `hhfab vlab up` command. It will automatically start all VMs and run
-the installers on the control node and test servers. It will take some time for all VMs to come up and for the installer
-to finish, you will see the progress in the output. If you stop the command, it'll stop all VMs, and you can re-run it
-to get VMs back up and running.
+As soon as the build has completed, you can run the VLAB using `hhfab vlab up`. This command automatically starts all
+VMs and runs the installers on the control node and test servers. It takes some time for all VMs to come up and for the
+installer to finish. You can monitor progress in the output. If you stop the command, it will stop all VMs, and you can
+re-run it to get VMs back up and running.
 
 ## Run VMs and installers
 
@@ -164,23 +164,25 @@ ubuntu@docs:~$ hhfab vlab up
 01:35:15 INF VM installed name=control-1 type=control installer=control-install
 ```
 
-After you see `VM installed name=control-1`, it means that the installer has finished and you can get into the control
-node and other VMs to watch the Fabric coming up and switches getting provisioned.
+Line `VM installed name=control-1` from the installer's output means that the installer has finished. After this line
+has been displayed, you can get into the control node and other VMs to watch the Fabric coming up and switches getting
+provisioned.
 
 ## Configuring VLAB VMs
 
-By default, all test server VMs are isolated and have no connectivity to the host or internet. You can configure it
-using `hhfab vlab up --restrict-servers=false` flag to allow the test servers to access the internet and the host. It
-will mean that VMs will have default route pointing to the host which means in case of the VPC peering you'll need to
-configure test server VMs to use the VPC attachment as a default route (or just some specific subnets).
+By default, all test server VMs are isolated and have no connectivity to the host or the Internet. You can configure
+enable connectivity using `hhfab vlab up --restrict-servers=false` to allow the test servers to access the Internet and
+the host. When you enable connectivity, VMs get a default route pointing to the host, which means that in case of the
+VPC peering you need to configure test server VMs to use the VPC attachment as a default route (or just some specific
+subnets).
 
-Additionally, you can configure the size of all VMs using `hhfab vlab up --vm-size <size>` flag. It will allow you to
-choose from one of the presets (compact, default, full and huge) to get the control, switch and server VMs of different
+Additionally, you can configure the size of all VMs using `hhfab vlab up --vm-size <size>`. The flag allows you to
+choose from one of the presets (compact, default, full and huge) to get the control, switch, and server VMs of different
 sizes.
 
 ## Default credentials
 
-Fabricator will create default users and keys for you to login into the control node and test servers as well as for the
+Fabricator creates default users and keys for you to login into the control node and test servers as well as for the
 SONiC Virtual Switches.
 
 Default user with passwordless sudo for the control node and test servers is `core` with password `HHFab.Admin!`.
@@ -219,11 +221,11 @@ Ready:          true
 Basedir:        .hhfab/vlab-vms/control-1
 ```
 
-On the control node you'll have access to the kubectl, Fabric CLI and k9s to manage the Fabric. You can find information
+On the control node you have access to kubectl, Fabric CLI, and k9s to manage the Fabric. You can find information
 about the switches provisioning by running `kubectl get agents -o wide`. It usually takes about 10-15 minutes for the
 switches to get installed.
 
-After switches are provisioned you will see something like this:
+After the switches are provisioned, the command returns something like this:
 
 ```console
 core@control-1 ~ $ kubectl get agents -o wide
@@ -235,21 +237,21 @@ spine-01   spine         VS-04           DellEMC-S5248f-P-25G-DPB   vs     26s  
 spine-02   spine         VS-05           DellEMC-S5248f-P-25G-DPB   vs     19s         3m53s     4          4          v0.23.0   4.1.1-Enterprise_Base   3m53s     4          10m
 ```
 
-`Heartbeat` column shows how long ago the switch has sent the heartbeat to the control node. `Applied` column shows how long
-ago the switch has applied the configuration. `AppliedG` shows the generation of the configuration applied. `CurrentG` shows
-the generation of the configuration the switch is supposed to run. If `AppliedG` and `CurrentG` are different it means that
-the switch is in the process of applying the configuration.
+The `Heartbeat` column shows how long ago the switch has sent the heartbeat to the control node. The `Applied` column
+shows how long ago the switch has applied the configuration. `AppliedG` shows the generation of the configuration
+applied. `CurrentG` shows the generation of the configuration the switch is supposed to run. Different values for
+`AppliedG` and `CurrentG` mean that the switch is in the process of applying the configuration.
 
 At that point Fabric is ready and you can use `kubectl` and `kubectl fabric` to manage the Fabric. You can find more
-about it in the [Running Demo](demo.md) and [User Guide](../user-guide/overview.md) sections.
+about managing the Fabric in the [Running Demo](demo.md) and [User Guide](../user-guide/overview.md) sections.
 
 ## Getting main Fabric objects
 
-You can get the main Fabric objects using `kubectl get` command on the control node. You can find more details about
+You can list the main Fabric objects by running `kubectl get` on the control node. You can find more details about
 using the Fabric in the [User Guide](../user-guide/overview.md), [Fabric API](../reference/api.md) and
 [Fabric CLI](../reference/cli.md) sections.
 
- For example, to get the list of switches you can run:
+For example, to get the list of switches, run:
 
 ```console
 core@control-1 ~ $ kubectl get switch
@@ -261,7 +263,7 @@ spine-01   spine         VS-04                    3e2c4992-a2e4-594b-bbd1-f8b2fd
 spine-02   spine         VS-05                    96fbd4eb-53b5-5a4c-8d6a-bbc27d883030   6h10m
 ```
 
-Similar for the servers:
+Similarly, to get the list of servers, run:
 
 ```console
 core@control-1 ~ $ kubectl get server
@@ -275,7 +277,7 @@ server-05             S-05 Unbundled leaf-03       6h10m
 server-06             S-06 Bundled leaf-03         6h10m
 ```
 
-For connections:
+For connections, use:
 
 ```console
 core@control-1 ~ $ kubectl get connection
@@ -303,7 +305,7 @@ spine-02--fabric--leaf-02            fabric         6h11m
 spine-02--fabric--leaf-03            fabric         6h11m
 ```
 
-For IPv4 and VLAN namespaces:
+For IPv4 and VLAN namespaces, use:
 
 ```console
 core@control-1 ~ $ kubectl get ipns


### PR DESCRIPTION
- Makefile: Fix "help" target
- Fix formatting of ONIE's install logs
- Reformat and clean-up ONIE install instructions
- Change "ONiE/HONiE" to "ONIE/HONIE"
- Use "console" rather than "bash" as language to highlight code blocks
- Fix indent level for nested lists
- Use admonitions rather than citations
- Clean-up style, formatting, typos

This is a large clean-up for style in the documentation. Most commits are easy to review, but the last... Well the last is most of the style or typo changes, text re-wrapping makes everything worse, and it will be awful to review, apologies. I tried to split it more based on the type of the fixes but several lines would be updated for multiple reasons, making the amount of changes even larger.

Obviously, all changes in this PR are suggestions, and I'm happy to drop any of it if they're not desirable (Seeing the number of occurrences for “Leafs”, for example, I don't know if the correction to “Leaves” was acceptable).
