### PR TITLE
Consent related forms

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,11 +51,6 @@ extra:
     provider: mike
     default: latest
   consent:
-    analytics:
-      name: Github
-      checked: false
-      name: Google
-      checked: true
     title: Cookie consent
     description:
       We use cookies to recognize your repeated visits and preferences, as well
@@ -66,6 +61,13 @@ extra:
        - manage
        - accept
        - reject
+    cookies:
+      analytics:
+        name: Google Analytics
+        checked: true
+      github:
+        name: GitHub
+        checked: false
   analytics:
     provider: google
     property: G-NZSPQEJNFH

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,7 +50,7 @@ extra:
     default: latest
   analytics:
     provider: google
-    property: G-KFB7X75QW5
+    property: G-NZSPQEJNFH
   consent:
     title: Cookie consent
     description:
@@ -62,7 +62,6 @@ extra:
        - manage
        - accept
        - reject
-
   social:
     - icon: fontawesome/brands/linkedin
       link: https://www.linkedin.com/company/githedgehog/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,17 @@ extra:
   analytics:
     provider: google
     property: G-KFB7X75QW5
+  consent:
+    title: Cookie consent
+    description:
+      We use cookies to recognize your repeated visits and preferences, as well
+      as to measure the effectiveness of our documentation and whether users
+      find what they're searching for. With your consent, you're helping us to
+      make our documentation better.
+    actions:
+       - manage
+       - accept
+       - reject
 
   social:
     - icon: fontawesome/brands/linkedin

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,9 @@ site_name: Open Network Fabric
 site_url: https://docs.githedgehog.com/
 site_description: Hedgehog Open Network Fabric Documentation
 site_author: Hedgehog Authors
-copyright: ©2023 Hedgehog
+copyright:
+  Copyright &copy; 2023 Hedgehog
+  <a href="#__consent">Change cookie settings</a>
 
 theme:
   name: material
@@ -48,10 +50,12 @@ extra:
   version:
     provider: mike
     default: latest
-  analytics:
-    provider: google
-    property: G-NZSPQEJNFH
   consent:
+    analytics:
+      name: Github
+      checked: false
+      name: Google
+      checked: true
     title: Cookie consent
     description:
       We use cookies to recognize your repeated visits and preferences, as well
@@ -62,6 +66,10 @@ extra:
        - manage
        - accept
        - reject
+  analytics:
+    provider: google
+    property: G-NZSPQEJNFH
+
   social:
     - icon: fontawesome/brands/linkedin
       link: https://www.linkedin.com/company/githedgehog/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,10 @@ extra:
   version:
     provider: mike
     default: latest
+  analytics:
+    provider: google
+    property: G-KFB7X75QW5
+
   social:
     - icon: fontawesome/brands/linkedin
       link: https://www.linkedin.com/company/githedgehog/


### PR DESCRIPTION
Turn on the cookie banner - 
We might not NEED it for California stuff - [here](https://cppa.ca.gov/faq.html#faq_cppa_4_body)
According to the material-mkdocs GDPR says we need to be able to cookie consent at any time. This has been added. We are relying on material-mkdocs to have done the plumbing to actually turn off the tracking when the user says so. 