### PR TITLE
Update copyright year in footer

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,8 @@ site_url: https://docs.githedgehog.com/
 site_description: Hedgehog Open Network Fabric Documentation
 site_author: Hedgehog Authors
 copyright:
-  Copyright &copy; 2023 Hedgehog
+  Copyright &copy; 2024 Hedgehog
+  &#x25cf;
   <a href="#__consent">Change cookie settings</a>
 
 theme:


### PR DESCRIPTION
Also add a dot to visually separate the copyright mention from the link to update the cookies policy.
