### PR TITLE
Add links to previous and next page in footer

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ theme:
     - navigation.expand
     - toc.follow
     - navigation.top
+    - navigation.footer
     - search.suggest
     - search.highlight
     - search.share


### PR DESCRIPTION
Several sections of the docs, such as the installation part, the whole user guide, or the different steps of running the VLAB, are easy to read in a continuous fashion: start with the first page, follow-up with the next ones.

To help with navigation in such cases, add links to the previous and following pages of the documentation to the footer.

Link: https://squidfunk.github.io/mkdocs-material/setup/setting-up-the-footer/
