### PR TITLE
Upgrade instructions: Add tabs for Linux/macOS instructions

### DIFF
--- a/docs/install-upgrade/install.md
+++ b/docs/install-upgrade/install.md
@@ -57,13 +57,15 @@ The installer for the fabric is generated in `$CWD/result/`. This installation i
 !!! warning ""
     This will erase data on the USB disk.
 
-### Steps for Linux
+=== "Linux"
+
 1. Insert the USB to your machine
 1. Identify the path to your USB stick, for example: `/dev/sdc`
 1. Issue the command to write the image to the USB drive
     - `sudo dd if=control-1-install-usb.img of=/dev/sdc bs=4k status=progress`
 
-### Steps for MacOS
+=== "macOS"
+
 1. Plug the drive into the computer
 1. Open the terminal
 1. Identify the drive using `diskutil list`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ theme:
   features:
     - announce.dismiss
     - content.action.edit
+    - content.tabs.link
     - navigation.instant
     - navigation.instant.progress
     - navigation.tracking


### PR DESCRIPTION
Introduce the use of content tabs in the docs, because it looks nice and fancy.

Fix the case on “macOS”.
