### PR TITLE
feat: migrate to docs.hedgehog.cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 [![Netlify Status](https://api.netlify.com/api/v1/badges/76ba2fb4-b33a-4f0f-b81d-c61e3b603bc9/deploy-status)](https://app.netlify.com/sites/hedgehog-docs/deploys)
 
-Published to [https://docs.githedgehog.com](https://docs.githedgehog.com).
+Published to [https://docs.hedgehog.cloud](https://docs.hedgehog.cloud).

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -6,7 +6,7 @@ To make network switches Kubernetes-aware, the Fabric employs an **Agent** runni
 
 ## Components
 
-Hedgehog Fabric consists of several key components, distributed between the Control Node and the Network devices. The following diagram breaks down the components of a [Collapsed Core](https://docs.githedgehog.com/latest/architecture/fabric/#collapsed-core). Hedgehog components have been highlighted in brown color:
+Hedgehog Fabric consists of several key components, distributed between the Control Node and the Network devices. The following diagram breaks down the components of a [Collapsed Core](fabric.md#collapsed-core). Hedgehog components have been highlighted in brown color:
 
 ``` mermaid
 graph TD;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Open Network Fabric
-site_url: https://docs.githedgehog.com/
+site_url: https://docs.hedgehog.cloud/
 site_description: Hedgehog Open Network Fabric Documentation
 site_author: Hedgehog Authors
 copyright:
@@ -49,7 +49,7 @@ theme:
         name: Switch to light mode
 
 extra:
-  homepage: https://docs.githedgehog.com
+  homepage: https://docs.hedgehog.cloud
   version:
     provider: mike
     default: latest


### PR DESCRIPTION
I've already made docs available at docs.hedgehog.cloud but things like clicking on the company logo redirects to the old URL.