### PR TITLE
ci: skip conventional commits check

### DIFF
--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -1,6 +1,3 @@
-# Make sure commit subject and description follow the Conventional Commits spec.
-# See https://www.conventionalcommits.org/
-
 name: "commitlint"
 
 on:
@@ -23,11 +20,6 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: "false"
-
-      - name: Run commitlint on Pull Request's commits
-        uses: opensource-nepal/commitlint@v1
-        with:
-          verbose: true
 
       - name: Block Merge Commits
         if: ${{ always() }}


### PR DESCRIPTION
Per conversation in https://github.com/githedgehog/docs/pull/85 with @qmonnet we shouldn't really care much about commit messages in the docs repo, just make sure to preserve linear history for backporting to the release branches