### PR TITLE
ci: Break CI build on broken links, ommitted files

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
         uses: extractions/setup-just@v2
 
       - name: Build docs
-        run: just build
+        run: just build --strict
 
       - name: Deploy preview to Netlify
         uses: nwtgck/actions-netlify@v2

--- a/Justfile
+++ b/Justfile
@@ -14,7 +14,7 @@ _run +cmd:
   docker run -q --pull=always --rm -v $(pwd):/docs -p 8000:8000 {{image}} {{cmd}}
 
 # Build docs site (unversioned)
-build: (_run "mkdocs build")
+build *opts: (_run "mkdocs build" opts)
 
 # Clean generated docs site
 clean:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -133,6 +133,12 @@ markdown_extensions:
       emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:material.extensions.emoji.to_svg
 
+validation:
+  omitted_files: warn
+  absolute_links: warn
+  unrecognized_links: warn
+  anchors: warn
+
 watch:
   - includes
   - overrides


### PR DESCRIPTION
Mkdocs is able to detect broken links or files ommitted from the "nav" configuration, etc. By default, it reports them at the "INFO" level. Instead, we can have "mkdocs build" report them as warnings. To do so, we follow the documentation's "recommended settings for most sites (maximal strictness)" (see [docs])

Once "mkdocs build" emits warnings for these issues, we can use the strict mode (-s|--strict) to have the build error out if anything looks wrong. Let's use this in CI to detect broken links, for example.

[docs]: https://www.mkdocs.org/user-guide/configuration/#validation

> [!WARNING]
> Doesn't pass CI yet, because we currently have a few broken links in the API reference. See githedgehog/fabric#809.
