### PR TITLE
chore(reference): add profile feature summary table

### DIFF
--- a/docs/reference/profiles.md
+++ b/docs/reference/profiles.md
@@ -1076,4 +1076,23 @@ Label column is a port label on a physical switch.
 | E1/47 | 47 | Port Group | 12 | 25G | 10G, 25G |
 | E1/48 | 48 | Port Group | 12 | 25G | 10G, 25G |
 
+## Switch Feature Matrix
 
+The following table shows which features are supported by each switch profile:
+
+| Switch Profile | RoCE | QPN | SubIf | L3VNI | L2VNI | ESLAG | MCLAG | ACLs |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| [ds2000](#celestica-ds2000) | :material-close: | :material-close: | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
+| [ds3000](#celestica-ds3000) | :material-check: | :material-close: | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
+| [ds4000](#celestica-ds4000) | :material-check: | :material-close: | :material-close: | :material-close: | :material-close: | :material-close: | :material-close: | :material-check: |
+| [ds4101](#celestica-ds4101) | :material-check: | :material-check: | :material-close: | :material-close: | :material-close: | :material-close: | :material-close: | :material-check: |
+| [ds5000](#celestica-ds5000) | :material-check: | :material-check: | :material-check: | :material-check: | :material-close: | :material-close: | :material-close: | :material-check: |
+| [s5232f](#dell-s5232f-on) | :material-check: | :material-close: | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
+| [s5248f](#dell-s5248f-on) | :material-check: | :material-close: | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
+| [z9332f](#dell-z9332f-on) | :material-check: | :material-close: | :material-close: | :material-close: | :material-close: | :material-close: | :material-close: | :material-check: |
+| [dcs203](#edgecore-dcs203) | :material-check: | :material-close: | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
+| [dcs204](#edgecore-dcs204) | :material-check: | :material-close: | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
+| [dcs501](#edgecore-dcs501) | :material-close: | :material-close: | :material-close: | :material-close: | :material-close: | :material-close: | :material-close: | :material-check: |
+| [eps203](#edgecore-eps203) | :material-close: | :material-close: | :material-close: | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
+| [c4632sb](#supermicro-sse-c4632sb) | :material-check: | :material-close: | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
+| [vs](#virtual-switch) | :material-check: | :material-close: | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: | :material-close: |


### PR DESCRIPTION
To have a quick overview of existing/supported features per switch type