### PR TITLE
docs(vlab): explain how to read test-connectivity output

### DIFF
--- a/docs/vlab/demo.md
+++ b/docs/vlab/demo.md
@@ -256,6 +256,28 @@ OPTIONS:
    --workdir PATH   run as if hhfab was started in PATH instead of the current working directory (default: "/home/ubuntu/hhfab") [$HHFAB_WORK_DIR]
 
 ```
+
+#### How to read the output
+
+`test-connectivity` reports whether the *observed* behaviour matches the
+*intent* declared on the fabric, not whether every ping succeeds. For each
+pair of servers it first reads the VPCs, VPCPeering objects, and
+GatewayPeering objects to determine the intended reachability, then runs a
+probe (ping, iperf3, or curl) and compares the result to that expectation:
+
+| Intent declares | What the probe shows | Test result |
+|---|---|---|
+| Should be reachable | Probe succeeds | ✅ pass: working as designed |
+| Should be reachable | Probe fails | ❌ fail: the fabric is not delivering traffic it should |
+| Should **not** be reachable | Probe fails | ✅ pass: isolation is working as designed |
+| Should not be reachable | Probe succeeds | ❌ fail: traffic is leaking across an unintended boundary |
+
+!!! note
+    A failing probe is not a failing test. Each per-pair log line carries
+    an `expected=` field: real failures are probes that fail with
+    `expected=true` or succeed with `expected=false`. For overall health,
+    read the summary at the end of the run rather than individual probes.
+
 ## Manual VPC creation
 ### Creating and attaching VPCs
 


### PR DESCRIPTION
The Test Connectivity section in vlab/demo.md only showed the --help output. Newcomers to the tool repeatedly mis-read the per-pair logs: they see lines reporting "100% packet loss" or "connection refused", assume the fabric is broken, and miss that the test was deliberately checking that those pairs cannot reach each other.

Add a short "How to read the output" subsection that:
- frames the tool as comparing observed behaviour against the configured policy, not just running pings
- gives the four expected/observed combinations as a table, with the surprising "should not be reachable + probe fails = pass" row called out so it doesn't trip up readers