### PR TITLE
chore: make mkdocs build strict to catch broken links

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -14,7 +14,7 @@ _run +cmd:
   docker run -q --pull=always --rm -v $(pwd):/docs -p 8000:8000 {{image}} {{cmd}}
 
 # Build docs site (unversioned)
-build: (_run "mkdocs build")
+build: (_run "mkdocs build --strict")
 
 # Clean generated docs site
 clean:

--- a/docs/user-guide/grafana.md
+++ b/docs/user-guide/grafana.md
@@ -1,7 +1,7 @@
 # Grafana Dashboards
 
 To provide monitoring for most critical metrics from the switches managed by Hedgehog Fabric there are several Dashboards that may be used in Grafana deployments. Make sure that you've enabled metrics and logs collection for the switches in the Fabric that is
-described in [Fabric Config](../install-upgrade/config.md#telemetry) section.
+described in [Fabric Config](../user-guide/o11y-config.md) section.
 
 ## Variables
 List of common variables used in Hedgehog Grafana dashboards
@@ -150,4 +150,3 @@ Dashboard ID:
 ```
 24419
 ```
-

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -136,3 +136,14 @@ markdown_extensions:
 watch:
   - includes
   - overrides
+
+validation:
+  nav:
+    omitted_files: warn
+    not_found: warn
+    absolute_links: warn
+  links:
+    not_found: warn
+    anchors: warn
+    absolute_links: warn
+    unrecognized_links: warn


### PR DESCRIPTION
It should be passing after we'll get updated docs from fabric and fabricator.